### PR TITLE
update the path to assets

### DIFF
--- a/css/metadata.scss
+++ b/css/metadata.scss
@@ -73,7 +73,7 @@ $default-font-size: 22px;
     }
 
     .op-cover {
-        background-image: url('../markdown/assets/OpenProject-slide-16-9.jpg');
+        background-image: url('../templates/assets/OpenProject-slide-16-9.jpg');
         background-repeat: no-repeat;
         background-size: cover;
         background-position: center;

--- a/templates/cover-template.html
+++ b/templates/cover-template.html
@@ -16,6 +16,6 @@
 <div class="footer-item">
 </div>
 <div class="footer-item footer-logo">
-<img src="markdown/assets/op-logo-dark.png" alt="Logo"></div>
+<img src="templates/assets/op-logo-dark.png" alt="Logo"></div>
 </footer>
 </script>

--- a/templates/op-cover-template.html
+++ b/templates/op-cover-template.html
@@ -3,7 +3,7 @@
 <div class="content-wrapper">
 
 <div class="cover-logo">
-<img src="markdown/assets/op-logo-dark.png" alt="Logo">
+<img src="templates/assets/op-logo-dark.png" alt="Logo">
 </div>
 
 <div class="content">

--- a/templates/section-template.html
+++ b/templates/section-template.html
@@ -21,6 +21,6 @@
 <div class="footer-item custom-slide-number">
 </div>
 <div class="footer-item footer-logo">
-<img src="markdown/assets/op-logo-light.png" alt="Logo"></div>
+<img src="templates/assets/op-logo-light.png" alt="Logo"></div>
 </footer>
 </script>

--- a/templates/title-content-image-template.html
+++ b/templates/title-content-image-template.html
@@ -18,6 +18,6 @@
 <div class="footer-item custom-slide-number">
 </div>
 <div class="footer-item footer-logo">
-<img src="markdown/assets/op-logo-light.png" alt="Logo"></div>
+<img src="templates/assets/op-logo-light.png" alt="Logo"></div>
 </footer>
 </script>

--- a/templates/title-content-template.html
+++ b/templates/title-content-template.html
@@ -19,6 +19,6 @@
 <div class="footer-item custom-slide-number">
 </div>
 <div class="footer-item footer-logo">
-<img src="markdown/assets/op-logo-light.png" alt="Logo"></div>
+<img src="templates/assets/op-logo-light.png" alt="Logo"></div>
 </footer>
 </script>

--- a/tests/unit/jest/__snapshots__/presentation.spec.js.snap
+++ b/tests/unit/jest/__snapshots__/presentation.spec.js.snap
@@ -35,7 +35,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -100,7 +100,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -127,7 +127,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -152,7 +152,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -183,7 +183,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -214,7 +214,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -245,7 +245,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -276,7 +276,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -307,7 +307,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -338,7 +338,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -397,7 +397,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -425,7 +425,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -452,7 +452,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -479,7 +479,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -506,7 +506,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -533,7 +533,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -560,7 +560,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -587,7 +587,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -614,7 +614,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -641,7 +641,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -668,7 +668,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -695,7 +695,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -722,7 +722,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -749,7 +749,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -776,7 +776,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -803,7 +803,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -830,7 +830,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -857,7 +857,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -884,7 +884,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -911,7 +911,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -938,7 +938,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -948,7 +948,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
             <div class="slide-background op-cover present" data-loaded="true" style="display: block;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -1314,7 +1314,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -1379,7 +1379,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1406,7 +1406,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1431,7 +1431,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1462,7 +1462,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1493,7 +1493,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1524,7 +1524,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1555,7 +1555,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1586,7 +1586,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1617,7 +1617,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -1676,7 +1676,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -1704,7 +1704,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1731,7 +1731,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1758,7 +1758,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1785,7 +1785,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1812,7 +1812,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1839,7 +1839,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1866,7 +1866,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1893,7 +1893,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1920,7 +1920,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1947,7 +1947,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -1974,7 +1974,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2001,7 +2001,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2028,7 +2028,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2055,7 +2055,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2082,7 +2082,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2109,7 +2109,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2136,7 +2136,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2163,7 +2163,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2190,7 +2190,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2217,7 +2217,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2227,7 +2227,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: block;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -2591,7 +2591,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -2656,7 +2656,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2684,7 +2684,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2709,7 +2709,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2740,7 +2740,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2771,7 +2771,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2802,7 +2802,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2833,7 +2833,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2864,7 +2864,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -2895,7 +2895,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -2954,7 +2954,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -2982,7 +2982,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3009,7 +3009,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3036,7 +3036,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3063,7 +3063,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3090,7 +3090,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3117,7 +3117,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3144,7 +3144,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3171,7 +3171,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3198,7 +3198,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3225,7 +3225,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3252,7 +3252,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3279,7 +3279,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3306,7 +3306,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3333,7 +3333,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3360,7 +3360,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3387,7 +3387,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3414,7 +3414,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3441,7 +3441,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3468,7 +3468,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3495,7 +3495,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3505,7 +3505,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: block;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -3869,7 +3869,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -3934,7 +3934,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3962,7 +3962,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -3985,7 +3985,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4016,7 +4016,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4047,7 +4047,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4078,7 +4078,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4109,7 +4109,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4140,7 +4140,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4171,7 +4171,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -4230,7 +4230,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -4258,7 +4258,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4285,7 +4285,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4312,7 +4312,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4339,7 +4339,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4366,7 +4366,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4393,7 +4393,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4420,7 +4420,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4447,7 +4447,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4474,7 +4474,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4501,7 +4501,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4528,7 +4528,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4555,7 +4555,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4582,7 +4582,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4609,7 +4609,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4636,7 +4636,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4663,7 +4663,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4690,7 +4690,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4717,7 +4717,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4744,7 +4744,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4771,7 +4771,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -4781,7 +4781,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -5145,7 +5145,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -5210,7 +5210,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5238,7 +5238,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5261,7 +5261,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5290,7 +5290,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5321,7 +5321,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5352,7 +5352,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5383,7 +5383,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5414,7 +5414,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5445,7 +5445,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -5504,7 +5504,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -5532,7 +5532,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5559,7 +5559,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5586,7 +5586,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5613,7 +5613,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5640,7 +5640,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5667,7 +5667,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5694,7 +5694,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5721,7 +5721,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5748,7 +5748,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5775,7 +5775,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5802,7 +5802,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5829,7 +5829,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5856,7 +5856,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5883,7 +5883,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5910,7 +5910,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5937,7 +5937,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5964,7 +5964,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -5991,7 +5991,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6018,7 +6018,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6045,7 +6045,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6055,7 +6055,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -6419,7 +6419,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -6484,7 +6484,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6512,7 +6512,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6535,7 +6535,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6564,7 +6564,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6593,7 +6593,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6624,7 +6624,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6655,7 +6655,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6686,7 +6686,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6717,7 +6717,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -6776,7 +6776,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -6804,7 +6804,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6831,7 +6831,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6858,7 +6858,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6885,7 +6885,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6912,7 +6912,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6939,7 +6939,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6966,7 +6966,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -6993,7 +6993,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7020,7 +7020,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7047,7 +7047,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7074,7 +7074,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7101,7 +7101,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7128,7 +7128,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7155,7 +7155,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7182,7 +7182,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7209,7 +7209,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7236,7 +7236,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7263,7 +7263,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7290,7 +7290,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7317,7 +7317,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7327,7 +7327,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -7691,7 +7691,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -7756,7 +7756,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7784,7 +7784,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7807,7 +7807,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7836,7 +7836,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7865,7 +7865,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7894,7 +7894,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7925,7 +7925,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7956,7 +7956,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -7987,7 +7987,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -8046,7 +8046,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -8074,7 +8074,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8101,7 +8101,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8128,7 +8128,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8155,7 +8155,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8182,7 +8182,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8209,7 +8209,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8236,7 +8236,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8263,7 +8263,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8290,7 +8290,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8317,7 +8317,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8344,7 +8344,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8371,7 +8371,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8398,7 +8398,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8425,7 +8425,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8452,7 +8452,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8479,7 +8479,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8506,7 +8506,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8533,7 +8533,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8560,7 +8560,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8587,7 +8587,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -8597,7 +8597,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -8961,7 +8961,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -9026,7 +9026,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9054,7 +9054,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9077,7 +9077,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9106,7 +9106,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9135,7 +9135,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9164,7 +9164,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9193,7 +9193,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9224,7 +9224,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9255,7 +9255,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -9314,7 +9314,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -9342,7 +9342,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9369,7 +9369,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9396,7 +9396,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9423,7 +9423,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9450,7 +9450,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9477,7 +9477,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9504,7 +9504,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9531,7 +9531,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9558,7 +9558,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9585,7 +9585,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9612,7 +9612,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9639,7 +9639,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9666,7 +9666,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9693,7 +9693,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9720,7 +9720,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9747,7 +9747,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9774,7 +9774,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9801,7 +9801,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9828,7 +9828,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9855,7 +9855,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -9865,7 +9865,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -10229,7 +10229,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -10294,7 +10294,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10322,7 +10322,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10345,7 +10345,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10374,7 +10374,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10403,7 +10403,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10432,7 +10432,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10461,7 +10461,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10490,7 +10490,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10521,7 +10521,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -10580,7 +10580,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -10608,7 +10608,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10635,7 +10635,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10662,7 +10662,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10689,7 +10689,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10716,7 +10716,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10743,7 +10743,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10770,7 +10770,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10797,7 +10797,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10824,7 +10824,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10851,7 +10851,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10878,7 +10878,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10905,7 +10905,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10932,7 +10932,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10959,7 +10959,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -10986,7 +10986,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11013,7 +11013,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11040,7 +11040,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11067,7 +11067,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11094,7 +11094,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11121,7 +11121,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11131,7 +11131,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -11495,7 +11495,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -11560,7 +11560,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11588,7 +11588,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11611,7 +11611,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11640,7 +11640,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11669,7 +11669,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11698,7 +11698,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11727,7 +11727,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11756,7 +11756,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11785,7 +11785,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -11844,7 +11844,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -11872,7 +11872,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11899,7 +11899,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11926,7 +11926,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11953,7 +11953,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -11980,7 +11980,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12007,7 +12007,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12034,7 +12034,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12061,7 +12061,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12088,7 +12088,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12115,7 +12115,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12142,7 +12142,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12169,7 +12169,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12196,7 +12196,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12223,7 +12223,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12250,7 +12250,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12277,7 +12277,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12304,7 +12304,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12331,7 +12331,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12358,7 +12358,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12385,7 +12385,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12395,7 +12395,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -12759,7 +12759,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -12824,7 +12824,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12852,7 +12852,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12875,7 +12875,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12904,7 +12904,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12933,7 +12933,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12962,7 +12962,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -12991,7 +12991,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13020,7 +13020,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13049,7 +13049,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -13106,7 +13106,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -13134,7 +13134,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13161,7 +13161,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13188,7 +13188,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13215,7 +13215,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13242,7 +13242,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13269,7 +13269,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13296,7 +13296,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13323,7 +13323,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13350,7 +13350,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13377,7 +13377,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13404,7 +13404,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13431,7 +13431,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13458,7 +13458,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13485,7 +13485,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13512,7 +13512,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13539,7 +13539,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13566,7 +13566,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13593,7 +13593,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13620,7 +13620,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13647,7 +13647,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -13657,7 +13657,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -14021,7 +14021,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -14086,7 +14086,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14114,7 +14114,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14137,7 +14137,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14166,7 +14166,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14195,7 +14195,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14224,7 +14224,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14253,7 +14253,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14282,7 +14282,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14311,7 +14311,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -14368,7 +14368,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -14397,7 +14397,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14424,7 +14424,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14451,7 +14451,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14478,7 +14478,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14505,7 +14505,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14532,7 +14532,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14559,7 +14559,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14586,7 +14586,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14613,7 +14613,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14640,7 +14640,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14667,7 +14667,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14694,7 +14694,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14721,7 +14721,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14748,7 +14748,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14775,7 +14775,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14802,7 +14802,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14829,7 +14829,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14856,7 +14856,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14883,7 +14883,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14910,7 +14910,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -14920,7 +14920,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -15284,7 +15284,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -15349,7 +15349,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15377,7 +15377,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15400,7 +15400,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15429,7 +15429,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15458,7 +15458,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15487,7 +15487,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15516,7 +15516,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15545,7 +15545,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15574,7 +15574,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -15631,7 +15631,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -15660,7 +15660,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15688,7 +15688,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15715,7 +15715,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15742,7 +15742,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15769,7 +15769,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15796,7 +15796,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15823,7 +15823,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15850,7 +15850,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15877,7 +15877,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15904,7 +15904,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15931,7 +15931,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15958,7 +15958,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -15985,7 +15985,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16012,7 +16012,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16039,7 +16039,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16066,7 +16066,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16093,7 +16093,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16120,7 +16120,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16147,7 +16147,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16174,7 +16174,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16184,7 +16184,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -16548,7 +16548,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -16613,7 +16613,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16641,7 +16641,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16664,7 +16664,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16693,7 +16693,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16722,7 +16722,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16751,7 +16751,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16780,7 +16780,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16809,7 +16809,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16838,7 +16838,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -16895,7 +16895,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -16924,7 +16924,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16952,7 +16952,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -16980,7 +16980,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17007,7 +17007,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17034,7 +17034,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17061,7 +17061,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17088,7 +17088,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17115,7 +17115,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17142,7 +17142,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17169,7 +17169,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17196,7 +17196,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17223,7 +17223,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17250,7 +17250,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17277,7 +17277,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17304,7 +17304,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17331,7 +17331,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17358,7 +17358,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17385,7 +17385,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17412,7 +17412,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17439,7 +17439,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17449,7 +17449,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -17813,7 +17813,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -17878,7 +17878,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17906,7 +17906,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17929,7 +17929,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17958,7 +17958,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -17987,7 +17987,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18016,7 +18016,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18045,7 +18045,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18074,7 +18074,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18103,7 +18103,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -18160,7 +18160,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -18189,7 +18189,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18217,7 +18217,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18245,7 +18245,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18273,7 +18273,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18300,7 +18300,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18327,7 +18327,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18354,7 +18354,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18381,7 +18381,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18408,7 +18408,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18435,7 +18435,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18462,7 +18462,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18489,7 +18489,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18516,7 +18516,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18543,7 +18543,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18570,7 +18570,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18597,7 +18597,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18624,7 +18624,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18651,7 +18651,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18678,7 +18678,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18705,7 +18705,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -18715,7 +18715,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -19079,7 +19079,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -19144,7 +19144,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19172,7 +19172,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19195,7 +19195,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19224,7 +19224,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19253,7 +19253,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19282,7 +19282,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19311,7 +19311,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19340,7 +19340,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19369,7 +19369,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -19426,7 +19426,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -19455,7 +19455,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19483,7 +19483,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19511,7 +19511,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19539,7 +19539,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19567,7 +19567,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19594,7 +19594,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19621,7 +19621,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19648,7 +19648,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19675,7 +19675,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19702,7 +19702,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19729,7 +19729,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19756,7 +19756,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19783,7 +19783,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19810,7 +19810,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19837,7 +19837,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19864,7 +19864,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19891,7 +19891,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19918,7 +19918,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19945,7 +19945,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19972,7 +19972,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -19982,7 +19982,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -20346,7 +20346,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -20411,7 +20411,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20439,7 +20439,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20462,7 +20462,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20491,7 +20491,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20520,7 +20520,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20549,7 +20549,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20578,7 +20578,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20607,7 +20607,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20636,7 +20636,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -20693,7 +20693,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -20722,7 +20722,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20750,7 +20750,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20778,7 +20778,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20806,7 +20806,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20834,7 +20834,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20862,7 +20862,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20889,7 +20889,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20916,7 +20916,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20943,7 +20943,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20970,7 +20970,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -20997,7 +20997,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21024,7 +21024,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21051,7 +21051,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21078,7 +21078,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21105,7 +21105,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21132,7 +21132,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21159,7 +21159,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21186,7 +21186,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21213,7 +21213,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21240,7 +21240,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21250,7 +21250,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -21614,7 +21614,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -21679,7 +21679,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21707,7 +21707,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21730,7 +21730,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21759,7 +21759,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21788,7 +21788,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21817,7 +21817,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21846,7 +21846,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21875,7 +21875,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -21904,7 +21904,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -21961,7 +21961,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -21990,7 +21990,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22018,7 +22018,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22046,7 +22046,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22074,7 +22074,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22102,7 +22102,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22130,7 +22130,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22158,7 +22158,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22185,7 +22185,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22212,7 +22212,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22239,7 +22239,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22266,7 +22266,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22293,7 +22293,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22320,7 +22320,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22347,7 +22347,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22374,7 +22374,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22401,7 +22401,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22428,7 +22428,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22455,7 +22455,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22482,7 +22482,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22509,7 +22509,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22519,7 +22519,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -22883,7 +22883,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -22948,7 +22948,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22976,7 +22976,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -22999,7 +22999,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23028,7 +23028,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23057,7 +23057,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23086,7 +23086,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23115,7 +23115,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23144,7 +23144,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23173,7 +23173,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -23230,7 +23230,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -23259,7 +23259,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23287,7 +23287,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23315,7 +23315,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23343,7 +23343,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23371,7 +23371,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23399,7 +23399,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23427,7 +23427,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23455,7 +23455,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23482,7 +23482,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23509,7 +23509,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23536,7 +23536,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23563,7 +23563,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23590,7 +23590,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23617,7 +23617,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23644,7 +23644,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23671,7 +23671,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23698,7 +23698,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23725,7 +23725,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23752,7 +23752,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23779,7 +23779,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -23789,7 +23789,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -24153,7 +24153,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -24218,7 +24218,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24246,7 +24246,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24269,7 +24269,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24298,7 +24298,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24327,7 +24327,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24356,7 +24356,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24385,7 +24385,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24414,7 +24414,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24443,7 +24443,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -24500,7 +24500,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -24529,7 +24529,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24557,7 +24557,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24585,7 +24585,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24613,7 +24613,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24641,7 +24641,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24669,7 +24669,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24697,7 +24697,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24725,7 +24725,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24753,7 +24753,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24780,7 +24780,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24807,7 +24807,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24834,7 +24834,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24861,7 +24861,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24888,7 +24888,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24915,7 +24915,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24942,7 +24942,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24969,7 +24969,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -24996,7 +24996,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25023,7 +25023,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25050,7 +25050,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25060,7 +25060,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -25424,7 +25424,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -25489,7 +25489,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25517,7 +25517,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25540,7 +25540,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25569,7 +25569,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25598,7 +25598,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25627,7 +25627,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25656,7 +25656,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25685,7 +25685,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25714,7 +25714,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -25771,7 +25771,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -25800,7 +25800,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25828,7 +25828,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25856,7 +25856,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25884,7 +25884,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25912,7 +25912,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25940,7 +25940,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25968,7 +25968,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -25996,7 +25996,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26024,7 +26024,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26052,7 +26052,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26079,7 +26079,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26106,7 +26106,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26133,7 +26133,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26160,7 +26160,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26187,7 +26187,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26214,7 +26214,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26241,7 +26241,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26268,7 +26268,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26295,7 +26295,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26322,7 +26322,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26332,7 +26332,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -26696,7 +26696,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -26761,7 +26761,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26789,7 +26789,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26812,7 +26812,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26841,7 +26841,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26870,7 +26870,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26899,7 +26899,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26928,7 +26928,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26957,7 +26957,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -26986,7 +26986,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -27043,7 +27043,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -27072,7 +27072,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27100,7 +27100,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27128,7 +27128,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27156,7 +27156,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27184,7 +27184,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27212,7 +27212,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27240,7 +27240,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27268,7 +27268,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27296,7 +27296,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27324,7 +27324,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27352,7 +27352,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27379,7 +27379,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27406,7 +27406,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27433,7 +27433,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27460,7 +27460,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27487,7 +27487,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27514,7 +27514,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27541,7 +27541,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27568,7 +27568,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27595,7 +27595,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -27605,7 +27605,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -27969,7 +27969,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -28034,7 +28034,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28062,7 +28062,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28085,7 +28085,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28114,7 +28114,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28143,7 +28143,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28172,7 +28172,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28201,7 +28201,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28230,7 +28230,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28259,7 +28259,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -28316,7 +28316,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -28345,7 +28345,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28373,7 +28373,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28401,7 +28401,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28429,7 +28429,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28457,7 +28457,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28485,7 +28485,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28513,7 +28513,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28541,7 +28541,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28569,7 +28569,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28597,7 +28597,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28625,7 +28625,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28653,7 +28653,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28680,7 +28680,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28707,7 +28707,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28734,7 +28734,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28761,7 +28761,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28788,7 +28788,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28815,7 +28815,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28842,7 +28842,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28869,7 +28869,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -28879,7 +28879,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -29243,7 +29243,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -29308,7 +29308,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29336,7 +29336,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29359,7 +29359,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29388,7 +29388,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29417,7 +29417,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29446,7 +29446,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29475,7 +29475,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29504,7 +29504,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29533,7 +29533,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -29590,7 +29590,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -29619,7 +29619,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29647,7 +29647,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29675,7 +29675,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29703,7 +29703,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29731,7 +29731,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29759,7 +29759,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29787,7 +29787,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29815,7 +29815,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29843,7 +29843,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29871,7 +29871,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29899,7 +29899,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29927,7 +29927,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29955,7 +29955,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -29982,7 +29982,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30009,7 +30009,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30036,7 +30036,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30063,7 +30063,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30090,7 +30090,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30117,7 +30117,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30144,7 +30144,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30154,7 +30154,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -30518,7 +30518,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -30583,7 +30583,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30611,7 +30611,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30634,7 +30634,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30663,7 +30663,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30692,7 +30692,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30721,7 +30721,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30750,7 +30750,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30779,7 +30779,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30808,7 +30808,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -30865,7 +30865,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -30894,7 +30894,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30922,7 +30922,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30950,7 +30950,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -30978,7 +30978,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31006,7 +31006,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31034,7 +31034,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31062,7 +31062,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31090,7 +31090,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31118,7 +31118,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31146,7 +31146,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31174,7 +31174,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31202,7 +31202,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31230,7 +31230,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31258,7 +31258,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31285,7 +31285,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31312,7 +31312,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31339,7 +31339,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31366,7 +31366,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31393,7 +31393,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31420,7 +31420,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31430,7 +31430,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -31794,7 +31794,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -31859,7 +31859,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31887,7 +31887,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31910,7 +31910,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31939,7 +31939,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31968,7 +31968,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -31997,7 +31997,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32026,7 +32026,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32055,7 +32055,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32084,7 +32084,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -32141,7 +32141,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -32170,7 +32170,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32198,7 +32198,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32226,7 +32226,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32254,7 +32254,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32282,7 +32282,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32310,7 +32310,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32338,7 +32338,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32366,7 +32366,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32394,7 +32394,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32422,7 +32422,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32450,7 +32450,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32478,7 +32478,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32506,7 +32506,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32534,7 +32534,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32562,7 +32562,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32589,7 +32589,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32616,7 +32616,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32643,7 +32643,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32670,7 +32670,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32697,7 +32697,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -32707,7 +32707,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -33071,7 +33071,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -33136,7 +33136,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33164,7 +33164,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33187,7 +33187,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33216,7 +33216,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33245,7 +33245,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33274,7 +33274,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33303,7 +33303,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33332,7 +33332,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33361,7 +33361,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -33418,7 +33418,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -33447,7 +33447,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33475,7 +33475,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33503,7 +33503,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33531,7 +33531,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33559,7 +33559,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33587,7 +33587,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33615,7 +33615,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33643,7 +33643,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33671,7 +33671,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33699,7 +33699,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33727,7 +33727,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33755,7 +33755,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33783,7 +33783,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33811,7 +33811,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33839,7 +33839,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33867,7 +33867,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33894,7 +33894,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33921,7 +33921,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33948,7 +33948,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33975,7 +33975,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -33985,7 +33985,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -34349,7 +34349,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -34414,7 +34414,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34442,7 +34442,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34465,7 +34465,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34494,7 +34494,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34523,7 +34523,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34552,7 +34552,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34581,7 +34581,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34610,7 +34610,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34639,7 +34639,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -34696,7 +34696,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -34725,7 +34725,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34753,7 +34753,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34781,7 +34781,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34809,7 +34809,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34837,7 +34837,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34865,7 +34865,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34893,7 +34893,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34921,7 +34921,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34949,7 +34949,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -34977,7 +34977,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35005,7 +35005,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35033,7 +35033,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35061,7 +35061,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35089,7 +35089,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35117,7 +35117,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35145,7 +35145,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35173,7 +35173,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35200,7 +35200,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35227,7 +35227,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35254,7 +35254,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35264,7 +35264,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -35628,7 +35628,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -35693,7 +35693,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35721,7 +35721,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35744,7 +35744,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35773,7 +35773,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35802,7 +35802,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35831,7 +35831,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35860,7 +35860,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35889,7 +35889,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -35918,7 +35918,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -35975,7 +35975,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -36004,7 +36004,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36032,7 +36032,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36060,7 +36060,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36088,7 +36088,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36116,7 +36116,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36144,7 +36144,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36172,7 +36172,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36200,7 +36200,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36228,7 +36228,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36256,7 +36256,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36284,7 +36284,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36312,7 +36312,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36340,7 +36340,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36368,7 +36368,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36396,7 +36396,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36424,7 +36424,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36452,7 +36452,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36480,7 +36480,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36507,7 +36507,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36534,7 +36534,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -36544,7 +36544,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -36908,7 +36908,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -36973,7 +36973,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37001,7 +37001,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37024,7 +37024,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37053,7 +37053,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37082,7 +37082,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37111,7 +37111,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37140,7 +37140,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37169,7 +37169,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37198,7 +37198,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -37255,7 +37255,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -37284,7 +37284,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37312,7 +37312,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37340,7 +37340,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37368,7 +37368,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37396,7 +37396,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37424,7 +37424,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37452,7 +37452,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37480,7 +37480,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37508,7 +37508,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37536,7 +37536,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37564,7 +37564,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37592,7 +37592,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37620,7 +37620,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37648,7 +37648,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37676,7 +37676,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37704,7 +37704,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37732,7 +37732,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37760,7 +37760,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37788,7 +37788,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37815,7 +37815,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -37825,7 +37825,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>
@@ -38189,7 +38189,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="content-wrapper">
 
                         <div class="cover-logo">
-                            <img src="markdown/assets/op-logo-dark.png" alt="Logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
                         </div>
 
                         <div class="content">
@@ -38254,7 +38254,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">2</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38282,7 +38282,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">3</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38305,7 +38305,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">4</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38334,7 +38334,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">5</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38363,7 +38363,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">6</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38392,7 +38392,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">7</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38421,7 +38421,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">8</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38450,7 +38450,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">9</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38479,7 +38479,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                         </div>
                         <div class="footer-item custom-slide-number">10</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -38536,7 +38536,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                         </div>
                         <div class="footer-item custom-slide-number">11</div>
                         <div class="footer-item footer-logo">
-                            <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
                         </div>
                     </footer>
 
@@ -38565,7 +38565,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">12</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38593,7 +38593,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">13</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38621,7 +38621,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38649,7 +38649,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38677,7 +38677,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38705,7 +38705,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38733,7 +38733,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38761,7 +38761,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38789,7 +38789,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38817,7 +38817,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38845,7 +38845,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38873,7 +38873,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38901,7 +38901,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38929,7 +38929,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38957,7 +38957,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -38985,7 +38985,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -39013,7 +39013,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -39041,7 +39041,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -39069,7 +39069,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -39097,7 +39097,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
-                        <img src="markdown/assets/op-logo-light.png" alt="Logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
                 </footer>
 
@@ -39107,7 +39107,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
                 <div class="slide-background-content">
                     <div class="image-overlay-container">
-                        <div class="image-container"><img src="markdown/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
                     </div>
                 </div>
             </div>

--- a/utils/exporter.js
+++ b/utils/exporter.js
@@ -60,7 +60,7 @@ async function exportAsHTML(url, outputUrl) {
         const sourceDir = './markdown/' + fileName
         const destinationDir = `${outputUri}/markdown/`
         await fs.copy(`${sourceDir}/`, `./${destinationDir}/${fileName}`, { overwrite: false })
-        await fs.copy('./markdown/assets', `./${destinationDir}/assets`, { overwrite: false })
+        await fs.copy('./templates/assets', `./${outputUri}/templates/assets`, { overwrite: false })
 
         console.info('✅ Static HTML export completed.')
         exec(

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -211,7 +211,7 @@ function addBackgroundOverlay() {
         const img = document.createElement('img')
         imageContainer.appendChild(img)
 
-        img.src = 'markdown/assets/OpenProject-Screen.png'
+        img.src = 'templates/assets/OpenProject-Screen.png'
         img.alt = 'cover page'
 
         img.style.borderRadius = '15px 0 0 15px'


### PR DESCRIPTION
### Description
After moving all templates and scripts to this repo we now have `assets` inside the `templates` directory (which used to be inside the markdown directory). This is done just to be on the safe side as the code have asset path as `markdown/assets` and the current structure there is no markdown directory in this repo. So, moved all assets into templates and updated the asset path to `templates/assets`.