### PR TITLE
[FIX] avoid crash when no cover page is provided

### DIFF
--- a/tests/unit/ymlConfig.test.js
+++ b/tests/unit/ymlConfig.test.js
@@ -20,6 +20,7 @@ slidenumber: no
 # OpenProject training ::slide:op-cover
 This is a template for a presentation
 
+
 # ::slide:toc
 
 # Overview traditional project managements ::slide:section`

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -125,7 +125,7 @@ function insertTocSlide(rawMarkdown) {
     const tocCoverRegex = /^#\s.*::slide:toc$/gm
 
     if (!tocCoverRegex.test(rawMarkdown)) {
-        tocString += '# ::slide:toc\n\n'
+        tocString += '\n# ::slide:toc\n\n'
         if (opCoverRegex.test(rawMarkdown)) {
             regex = /#{1,6}\s.+::slide:op-cover.*[^#]*/gm
         }


### PR DESCRIPTION
### Description
This PR fixes the issue regarding the presentation build crash when no cover page is provided in the config.yml file.

With no cover page provided the markdown content would result as follow:

```markdown
---
description: OpenProject für Profis
footer: OpenProject Adminschulung
presenter: Peter Lustig
language: de
---# ::slide:toc
```

This resulted in the invalid markdown content and resulting into the crash. 
So, adding an extra line in front of the Table Of Content slide.

### Related WP
https://community.openproject.org/projects/revealjs/work_packages/60575/activity