### PR TITLE
Fix slide numbering if there is no cover page in presentation

### DIFF
--- a/utils/helper.js
+++ b/utils/helper.js
@@ -4,8 +4,14 @@ const customSlideNumber = document.getElementsByClassName('custom-slide-number')
 
 // eslint-disable-next-line
 function addCustomSlideNumber(event) {
+    const firstSlide = Reveal.getSlide(0, 0)
+    const slideNumberElement = firstSlide.getElementsByClassName('custom-slide-number')
+    let slideNumberIncrement = 1
+    if (slideNumberElement.length === 0) {
+        slideNumberIncrement = 2
+    }
     Array.from(customSlideNumber).forEach(function (currentSlideNumber, index) {
-        currentSlideNumber.innerText = index + 2
+        currentSlideNumber.innerText = index + slideNumberIncrement
     })
 }
 


### PR DESCRIPTION
## Description
This PR fixes the slide numbering when no cover page exists in the presentation. Currently when there is no slide number the first slide numbering starts with 2. Now with the fix the slide numbering will start from 1.


## Related WP
https://community.openproject.org/projects/revealjs/work_packages/60599/activity