### PR TITLE
fix slide numbering

### DIFF
--- a/tests/unit/jest/__snapshots__/presentation.spec.js.snap
+++ b/tests/unit/jest/__snapshots__/presentation.spec.js.snap
@@ -435,60 +435,6 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -949,6 +895,60 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -2335,60 +2335,6 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -2849,6 +2795,60 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -4235,60 +4235,6 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -4749,6 +4695,60 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -6133,60 +6133,6 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -6647,6 +6593,60 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -8029,60 +8029,6 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -8543,6 +8489,60 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -9923,60 +9923,6 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -10437,6 +10383,60 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -11815,60 +11815,6 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -12329,6 +12275,60 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -13705,60 +13705,6 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -14219,6 +14165,60 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -15593,60 +15593,6 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -16107,6 +16053,60 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -17479,60 +17479,6 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -17993,6 +17939,60 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -19363,60 +19363,6 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -19877,6 +19823,60 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -21247,60 +21247,6 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -21761,6 +21707,60 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -23131,60 +23131,6 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -23192,7 +23138,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -23645,6 +23591,60 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -25016,60 +25016,6 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -25077,7 +25023,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -25104,7 +25050,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -25536,6 +25482,60 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 </footer>
 
             </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -25659,7 +25659,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.40625);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">2. Section Slide for long TOC footer content 12 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">2. Section Slide for long TOC footer content 14 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -26901,7 +26901,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -26929,60 +26929,6 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">14</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -26990,7 +26936,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -27017,7 +26963,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -27422,6 +27368,60 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 </footer>
 
             </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -27545,7 +27545,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.4375);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">3. Section Slide for long TOC footer content 13 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">3. Section Slide for long TOC footer content 15 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -28787,7 +28787,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -28815,7 +28815,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -28843,60 +28843,6 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">15</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -28904,7 +28850,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -28931,7 +28877,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -29309,6 +29255,60 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 </footer>
 
             </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -29432,7 +29432,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.46875);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">4. Section Slide for long TOC footer content 14 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">4. Section Slide for long TOC footer content 16 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -30674,7 +30674,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -30702,7 +30702,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -30730,7 +30730,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -30758,60 +30758,6 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">16</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -30819,7 +30765,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -30846,7 +30792,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -31197,6 +31143,60 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 </footer>
 
             </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -31320,7 +31320,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.5);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">5. Section Slide for long TOC footer content 15 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">5. Section Slide for long TOC footer content 17 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -32562,7 +32562,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -32590,7 +32590,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -32618,7 +32618,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -32646,7 +32646,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -32674,60 +32674,6 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">17</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -32735,7 +32681,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -32762,7 +32708,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -33086,6 +33032,60 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 </footer>
 
             </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -33209,7 +33209,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.53125);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">6. Section Slide for long TOC footer content 16 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">6. Section Slide for long TOC footer content 18 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -34451,7 +34451,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -34479,7 +34479,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -34507,7 +34507,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -34535,7 +34535,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -34563,7 +34563,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -34591,60 +34591,6 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">18</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -34652,7 +34598,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -34679,7 +34625,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -34976,6 +34922,60 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 </footer>
 
             </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -35099,7 +35099,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.5625);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">7. Section Slide for long TOC footer content 17 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">7. Section Slide for long TOC footer content 19 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -36341,7 +36341,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -36369,7 +36369,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -36397,7 +36397,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -36425,7 +36425,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -36453,7 +36453,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -36481,7 +36481,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -36509,60 +36509,6 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">18</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">19</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -36570,7 +36516,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -36597,7 +36543,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -36867,6 +36813,60 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 </footer>
 
             </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -36990,7 +36990,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.59375);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">8. Section Slide for long TOC footer content 18 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">8. Section Slide for long TOC footer content 20 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -38232,7 +38232,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -38260,7 +38260,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -38288,7 +38288,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -38316,7 +38316,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -38344,7 +38344,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -38372,7 +38372,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -38400,7 +38400,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -38428,60 +38428,6 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">19</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">20</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -38489,7 +38435,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -38516,7 +38462,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -38759,6 +38705,60 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 </footer>
 
             </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -38882,7 +38882,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.625);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">9. Section Slide for long TOC footer content 19 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">9. Section Slide for long TOC footer content 21 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -40124,7 +40124,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -40152,7 +40152,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -40180,7 +40180,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -40208,7 +40208,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -40236,7 +40236,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -40264,7 +40264,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -40292,7 +40292,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -40320,7 +40320,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">19</div>
+                    <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -40348,60 +40348,6 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">20</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">21</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -40409,7 +40355,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -40436,7 +40382,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -40652,6 +40598,60 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 </footer>
 
             </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -40775,7 +40775,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.65625);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">10. Section Slide for long TOC footer content 20 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">10. Section Slide for long TOC footer content 22 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -42017,7 +42017,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -42045,7 +42045,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -42073,7 +42073,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -42101,7 +42101,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -42129,7 +42129,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -42157,7 +42157,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -42185,7 +42185,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -42213,7 +42213,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">19</div>
+                    <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -42241,7 +42241,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">20</div>
+                    <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -42269,60 +42269,6 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">21</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">22</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -42330,7 +42276,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -42357,7 +42303,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -42546,6 +42492,60 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 </footer>
 
             </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -42669,7 +42669,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.6875);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">11. Section Slide for long TOC footer content 21 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">11. Section Slide for long TOC footer content 23 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -43911,7 +43911,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -43939,7 +43939,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -43967,7 +43967,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -43995,7 +43995,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -44023,7 +44023,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -44051,7 +44051,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -44079,7 +44079,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -44107,7 +44107,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">19</div>
+                    <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -44135,7 +44135,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">20</div>
+                    <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -44163,7 +44163,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">21</div>
+                    <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -44191,60 +44191,6 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">22</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">23</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -44252,7 +44198,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -44279,7 +44225,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -44441,6 +44387,60 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 </footer>
 
             </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -44564,7 +44564,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.71875);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">12. Section Slide for long TOC footer content 22 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">12. Section Slide for long TOC footer content 24 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -45806,7 +45806,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -45834,7 +45834,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -45862,7 +45862,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -45890,7 +45890,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -45918,7 +45918,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -45946,7 +45946,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -45974,7 +45974,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -46002,7 +46002,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">19</div>
+                    <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -46030,7 +46030,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">20</div>
+                    <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -46058,7 +46058,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">21</div>
+                    <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -46086,7 +46086,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">22</div>
+                    <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -46114,60 +46114,6 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">23</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">24</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -46175,7 +46121,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -46202,7 +46148,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -46337,6 +46283,60 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 </footer>
 
             </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -46460,7 +46460,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.75);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">13. Section Slide for long TOC footer content 23 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">13. Section Slide for long TOC footer content 25 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -47702,7 +47702,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -47730,7 +47730,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -47758,7 +47758,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -47786,7 +47786,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -47814,7 +47814,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -47842,7 +47842,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -47870,7 +47870,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -47898,7 +47898,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">19</div>
+                    <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -47926,7 +47926,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">20</div>
+                    <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -47954,7 +47954,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">21</div>
+                    <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -47982,7 +47982,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">22</div>
+                    <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -48010,7 +48010,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">23</div>
+                    <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -48038,60 +48038,6 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">24</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">25</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -48099,7 +48045,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -48126,7 +48072,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -48228,6 +48174,60 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -48357,7 +48357,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.78125);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">14. Section Slide for long TOC footer content 24 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">14. Section Slide for long TOC footer content 26 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -49599,7 +49599,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -49627,7 +49627,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -49655,7 +49655,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -49683,7 +49683,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -49711,7 +49711,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -49739,7 +49739,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -49767,7 +49767,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -49795,7 +49795,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">19</div>
+                    <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -49823,7 +49823,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">20</div>
+                    <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -49851,7 +49851,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">21</div>
+                    <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -49879,7 +49879,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">22</div>
+                    <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -49907,7 +49907,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">23</div>
+                    <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -49935,7 +49935,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">24</div>
+                    <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -49963,60 +49963,6 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">25</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">26</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -50024,7 +49970,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -50051,7 +49997,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -50126,6 +50072,60 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -50255,7 +50255,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.8125);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">15. Section Slide for long TOC footer content 25 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">15. Section Slide for long TOC footer content 27 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -51497,7 +51497,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -51525,7 +51525,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -51553,7 +51553,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -51581,7 +51581,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -51609,7 +51609,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -51637,7 +51637,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -51665,7 +51665,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -51693,7 +51693,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">19</div>
+                    <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -51721,7 +51721,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">20</div>
+                    <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -51749,7 +51749,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">21</div>
+                    <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -51777,7 +51777,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">22</div>
+                    <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -51805,7 +51805,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">23</div>
+                    <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -51833,7 +51833,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">24</div>
+                    <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -51861,7 +51861,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">25</div>
+                    <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -51889,60 +51889,6 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">26</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">27</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -51950,7 +51896,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -51977,7 +51923,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -52025,6 +51971,60 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -52154,7 +52154,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.84375);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">16. Section Slide for long TOC footer content 26 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">16. Section Slide for long TOC footer content 28 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -53396,7 +53396,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53424,7 +53424,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53452,7 +53452,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53480,7 +53480,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53508,7 +53508,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53536,7 +53536,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53564,7 +53564,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53592,7 +53592,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">19</div>
+                    <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53620,7 +53620,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">20</div>
+                    <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53648,7 +53648,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">21</div>
+                    <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53676,7 +53676,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">22</div>
+                    <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53704,7 +53704,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">23</div>
+                    <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53732,7 +53732,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">24</div>
+                    <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53760,7 +53760,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">25</div>
+                    <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53788,7 +53788,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">26</div>
+                    <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -53816,60 +53816,6 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">27</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">28</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
@@ -53877,7 +53823,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -53904,7 +53850,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                 </footer>
 
             </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
                 <div class="content-container">
                     <div class="content-wrapper">
 
@@ -53925,6 +53871,60 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -54054,7 +54054,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.875);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">17. Section Slide for long TOC footer content 27 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">17. Section Slide for long TOC footer content 29 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -55296,7 +55296,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55324,7 +55324,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55352,7 +55352,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55380,7 +55380,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55408,7 +55408,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55436,7 +55436,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55464,7 +55464,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55492,7 +55492,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">19</div>
+                    <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55520,7 +55520,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">20</div>
+                    <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55548,7 +55548,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">21</div>
+                    <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55576,7 +55576,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">22</div>
+                    <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55604,7 +55604,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">23</div>
+                    <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55632,7 +55632,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">24</div>
+                    <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55660,7 +55660,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">25</div>
+                    <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55688,7 +55688,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">26</div>
+                    <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55716,7 +55716,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">27</div>
+                    <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55744,61 +55744,61 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">28</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">29</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">30</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55825,7 +55825,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -55955,7 +55955,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.90625);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">18. Section Slide for long TOC footer content 28 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">18. Section Slide for long TOC footer content 30 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -57197,7 +57197,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57225,7 +57225,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57253,7 +57253,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57281,7 +57281,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57309,7 +57309,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57337,7 +57337,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57365,7 +57365,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57393,7 +57393,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">19</div>
+                    <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57421,7 +57421,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">20</div>
+                    <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57449,7 +57449,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">21</div>
+                    <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57477,7 +57477,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">22</div>
+                    <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57505,7 +57505,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">23</div>
+                    <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57533,7 +57533,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">24</div>
+                    <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57561,7 +57561,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">25</div>
+                    <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57589,7 +57589,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">26</div>
+                    <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57617,7 +57617,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">27</div>
+                    <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57645,7 +57645,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">28</div>
+                    <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57673,61 +57673,61 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">29</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
-                    <div class="footer-item custom-slide-number">30</div>
-                    <div class="footer-item footer-logo">
-                        <img src="templates/assets/op-logo-light.png" alt="Logo">
-                    </div>
-                </footer>
-
-            </section>
-            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
-                <div class="content-container">
-                    <div class="content-wrapper">
-
-                        <div class="content">
-                            <h1 class="title">
-                                Section Slide for long TOC
-                            </h1>
-
-
-
-                        </div>
-
-                    </div>
-                </div>
-
-                <footer>
-                    <div class="footer-item footer-title">
-                        <p>footer content</p>
-                    </div>
                     <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -57857,7 +57857,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.9375);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">19. Section Slide for long TOC footer content 29 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">19. Section Slide for long TOC footer content 31 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -59099,7 +59099,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59127,7 +59127,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59155,7 +59155,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59183,7 +59183,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59211,7 +59211,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59239,7 +59239,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59267,7 +59267,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59295,7 +59295,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">19</div>
+                    <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59323,7 +59323,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">20</div>
+                    <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59351,7 +59351,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">21</div>
+                    <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59379,7 +59379,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">22</div>
+                    <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59407,7 +59407,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">23</div>
+                    <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59435,7 +59435,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">24</div>
+                    <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59463,7 +59463,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">25</div>
+                    <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59491,7 +59491,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">26</div>
+                    <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59519,7 +59519,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">27</div>
+                    <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59547,7 +59547,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">28</div>
+                    <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59575,7 +59575,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">29</div>
+                    <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59603,7 +59603,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">30</div>
+                    <div class="footer-item custom-slide-number">32</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59630,7 +59630,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -59760,7 +59760,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(0.96875);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">20. Section Slide for long TOC footer content 30 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">20. Section Slide for long TOC footer content 32 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -61002,7 +61002,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">12</div>
+                    <div class="footer-item custom-slide-number">14</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61030,7 +61030,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">13</div>
+                    <div class="footer-item custom-slide-number">15</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61058,7 +61058,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item custom-slide-number">16</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61086,7 +61086,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item custom-slide-number">17</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61114,7 +61114,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item custom-slide-number">18</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61142,7 +61142,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item custom-slide-number">19</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61170,7 +61170,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item custom-slide-number">20</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61198,7 +61198,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">19</div>
+                    <div class="footer-item custom-slide-number">21</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61226,7 +61226,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">20</div>
+                    <div class="footer-item custom-slide-number">22</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61254,7 +61254,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">21</div>
+                    <div class="footer-item custom-slide-number">23</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61282,7 +61282,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">22</div>
+                    <div class="footer-item custom-slide-number">24</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61310,7 +61310,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">23</div>
+                    <div class="footer-item custom-slide-number">25</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61338,7 +61338,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">24</div>
+                    <div class="footer-item custom-slide-number">26</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61366,7 +61366,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">25</div>
+                    <div class="footer-item custom-slide-number">27</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61394,7 +61394,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">26</div>
+                    <div class="footer-item custom-slide-number">28</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61422,7 +61422,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">27</div>
+                    <div class="footer-item custom-slide-number">29</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61450,7 +61450,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">28</div>
+                    <div class="footer-item custom-slide-number">30</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61478,7 +61478,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">29</div>
+                    <div class="footer-item custom-slide-number">31</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61506,7 +61506,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">30</div>
+                    <div class="footer-item custom-slide-number">32</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61534,7 +61534,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="footer-item footer-title">
                         <p>footer content</p>
                     </div>
-                    <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item custom-slide-number">33</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -61664,7 +61664,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
         <div class="progress" style="display: block;"><span style="transform: scaleX(1);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">21. Section Slide for long TOC footer content 31 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">21. Section Slide for long TOC footer content 33 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -4,15 +4,14 @@ const customSlideNumber = document.getElementsByClassName('custom-slide-number')
 
 // eslint-disable-next-line
 function addCustomSlideNumber(event) {
-    const firstSlide = Reveal.getSlide(0, 0)
-    const slideNumberElement = firstSlide.getElementsByClassName('custom-slide-number')
-    let slideNumberIncrement = 1
-    if (slideNumberElement.length === 0) {
-        slideNumberIncrement = 2
+    const allSlides = Reveal.getSlides()
+    for (const [slideNumber, slide] of Array.from(allSlides).entries()) {
+        const customSlideNumber = slide.querySelector('.custom-slide-number')
+        if (!customSlideNumber) {
+            continue
+        }
+        customSlideNumber.textContent = slideNumber + 1
     }
-    Array.from(customSlideNumber).forEach(function (currentSlideNumber, index) {
-        currentSlideNumber.innerText = index + slideNumberIncrement
-    })
 }
 
 // eslint-disable-next-line


### PR DESCRIPTION
### Description
Slide numbering without cover page was fixed in the PR https://github.com/opf/revealjs-awesoMD-templates/pull/10. But, with the introduction of new slide type `image`, the slide number count did not match with the usage of the new slide type. So, this PR fixes the slide numbering considering every slide.