### PR TITLE
add support for markdown alerts

### DIFF
--- a/css/vendor.scss
+++ b/css/vendor.scss
@@ -2,3 +2,4 @@
 @import '../node_modules/reveal.js/dist/reveal.css';
 @import '../node_modules/reveal.js/dist/theme/white.css';
 @import '../node_modules/reveal.js/plugin/highlight/monokai.css';
+@import '../node_modules/revealjs-awesomd/dist/css/alerts.css';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 dependencies:
   revealjs-awesomd:
     specifier: github:opf/revealjs-awesomd
-    version: github.com/opf/revealjs-awesomd/7d04163ffee722531591edbf695cd47b25dbcc3d
+    version: github.com/opf/revealjs-awesomd/ef01d1776831352a55600ffacf5a2aaefc21e287
 
 devDependencies:
   browserify:
@@ -127,20 +127,20 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/core@7.26.0:
-    resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
+  /@babel/core@7.26.7:
+    resolution: {integrity: sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.26.2
       '@babel/generator': 7.26.5
       '@babel/helper-compilation-targets': 7.26.5
-      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
-      '@babel/helpers': 7.26.0
-      '@babel/parser': 7.26.5
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.7)
+      '@babel/helpers': 7.26.7
+      '@babel/parser': 7.26.7
       '@babel/template': 7.25.9
-      '@babel/traverse': 7.26.5
-      '@babel/types': 7.26.5
+      '@babel/traverse': 7.26.7
+      '@babel/types': 7.26.7
       convert-source-map: 2.0.0
       debug: 4.4.0
       gensync: 1.0.0-beta.2
@@ -154,8 +154,8 @@ packages:
     resolution: {integrity: sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/parser': 7.26.5
-      '@babel/types': 7.26.5
+      '@babel/parser': 7.26.7
+      '@babel/types': 7.26.7
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
@@ -176,22 +176,22 @@ packages:
     resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.26.5
-      '@babel/types': 7.26.5
+      '@babel/traverse': 7.26.7
+      '@babel/types': 7.26.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0):
+  /@babel/helper-module-transforms@7.26.0(@babel/core@7.26.7):
     resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.26.7
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.26.5
+      '@babel/traverse': 7.26.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -216,12 +216,12 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helpers@7.26.0:
-    resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
+  /@babel/helpers@7.26.7:
+    resolution: {integrity: sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.25.9
-      '@babel/types': 7.26.5
+      '@babel/types': 7.26.7
     dev: true
 
   /@babel/highlight@7.24.7:
@@ -234,12 +234,12 @@ packages:
       picocolors: 1.0.1
     dev: true
 
-  /@babel/parser@7.26.5:
-    resolution: {integrity: sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==}
+  /@babel/parser@7.26.7:
+    resolution: {integrity: sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.26.5
+      '@babel/types': 7.26.7
     dev: true
 
   /@babel/template@7.25.9:
@@ -247,27 +247,27 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.26.5
-      '@babel/types': 7.26.5
+      '@babel/parser': 7.26.7
+      '@babel/types': 7.26.7
     dev: true
 
-  /@babel/traverse@7.26.5:
-    resolution: {integrity: sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==}
+  /@babel/traverse@7.26.7:
+    resolution: {integrity: sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/generator': 7.26.5
-      '@babel/parser': 7.26.5
+      '@babel/parser': 7.26.7
       '@babel/template': 7.25.9
-      '@babel/types': 7.26.5
+      '@babel/types': 7.26.7
       debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/types@7.26.5:
-    resolution: {integrity: sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==}
+  /@babel/types@7.26.7:
+    resolution: {integrity: sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.25.9
@@ -380,7 +380,7 @@ packages:
       postcss: '>=7.0.0'
       postcss-syntax: '>=0.36.2'
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.26.7
       postcss: 7.0.39
       postcss-syntax: 0.36.2(postcss@8.4.38)
     transitivePeerDependencies:
@@ -520,7 +520,7 @@ packages:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.5
+      fast-uri: 3.0.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
     dev: true
@@ -799,7 +799,7 @@ packages:
     hasBin: true
     dependencies:
       browserslist: 4.24.4
-      caniuse-lite: 1.0.30001692
+      caniuse-lite: 1.0.30001696
       normalize-range: 0.1.2
       num2fraction: 1.2.2
       picocolors: 0.2.1
@@ -1146,8 +1146,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001692
-      electron-to-chromium: 1.5.80
+      caniuse-lite: 1.0.30001696
+      electron-to-chromium: 1.5.90
       node-releases: 2.0.19
       update-browserslist-db: 1.1.2(browserslist@4.24.4)
     dev: true
@@ -1249,8 +1249,8 @@ packages:
     resolution: {integrity: sha512-1x0qRI1mD1o9e+7mBI7XtzFAP4XszbHaVWsMiGbSPLYekKTJF7K+FNk6AsXH4sUpc+qrsI3pVgf1Jdl/uGkuSQ==}
     dev: true
 
-  /caniuse-lite@1.0.30001692:
-    resolution: {integrity: sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==}
+  /caniuse-lite@1.0.30001696:
+    resolution: {integrity: sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==}
     dev: true
 
   /chalk@2.4.2:
@@ -2031,8 +2031,8 @@ packages:
     resolution: {integrity: sha512-7L8fC2Ey/b6SePDFKR2zHAy4mbdp1/38Yk5TsARO66W3hC5KEaeKMMHoxwtuH+jcu2AYLSn9QX04i95t6Fl1Hg==}
     dev: true
 
-  /electron-to-chromium@1.5.80:
-    resolution: {integrity: sha512-LTrKpW0AqIuHwmlVNV+cjFYTnXtM9K37OGhpe0ZI10ScPSxqVSryZHIY3WnCS5NSYbBODRTZyhRMS2h5FAEqAw==}
+  /electron-to-chromium@1.5.90:
+    resolution: {integrity: sha512-C3PN4aydfW91Natdyd449Kw+BzhLmof6tzy5W1pFC5SpQxVXT+oyiyOG9AgYYSN9OdA/ik3YkCrpwqI8ug5Tug==}
     dev: true
 
   /elliptic@6.5.5:
@@ -2462,8 +2462,8 @@ packages:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
     dev: true
 
-  /fast-uri@3.0.5:
-    resolution: {integrity: sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==}
+  /fast-uri@3.0.6:
+    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
     dev: true
 
   /fastest-levenshtein@1.0.16:
@@ -4493,7 +4493,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.16.1
-      semver: 7.6.3
+      semver: 7.7.0
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -5619,6 +5619,12 @@ packages:
 
   /semver@7.6.3:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
+  /semver@7.7.0:
+    resolution: {integrity: sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==}
     engines: {node: '>=10'}
     hasBin: true
     dev: true
@@ -7081,8 +7087,8 @@ packages:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: true
 
-  github.com/opf/revealjs-awesomd/7d04163ffee722531591edbf695cd47b25dbcc3d:
-    resolution: {tarball: https://codeload.github.com/opf/revealjs-awesomd/tar.gz/7d04163ffee722531591edbf695cd47b25dbcc3d}
+  github.com/opf/revealjs-awesomd/ef01d1776831352a55600ffacf5a2aaefc21e287:
+    resolution: {tarball: https://codeload.github.com/opf/revealjs-awesomd/tar.gz/ef01d1776831352a55600ffacf5a2aaefc21e287}
     name: revealjs-awesomd
     version: 1.0.0
     dev: false

--- a/tests/unit/jest/__snapshots__/presentation.spec.js.snap
+++ b/tests/unit/jest/__snapshots__/presentation.spec.js.snap
@@ -88,6 +88,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -982,6 +983,74 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover present" data-loaded="true" style="display: block;">
@@ -1085,6 +1154,9 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                 <div class="slide-background-content"></div>
             </div>
             <div class="slide-background section future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
             <div class="slide-background title-content future" style="display: none;">
@@ -1326,6 +1398,12 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -1530,6 +1608,12 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -1733,6 +1817,12 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -1938,6 +2028,12 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -2015,7 +2111,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -2043,6 +2139,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -2937,6 +3034,74 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: block;">
@@ -3045,6 +3210,9 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -3060,10 +3228,10 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.030303);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.0294118);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">Table of Contents Section Slide Title Content Slide Title Content Image Slide Title Content Image Slide - scale down font Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Mermaid JS footer content 2 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">Table of Contents Section Slide Title Content Slide Title Content Image Slide Title Content Image Slide - scale down font Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Mermaid JS Support for alerts footer content 2 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -3280,6 +3448,12 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -3484,6 +3658,12 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -3687,6 +3867,12 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -3892,6 +4078,12 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -3969,7 +4161,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -3997,6 +4189,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -4892,6 +5085,74 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: block;">
@@ -5000,6 +5261,9 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -5015,7 +5279,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.0606061);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.0588235);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1. Section Slide footer content 3 </div>
@@ -5235,6 +5499,12 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -5439,6 +5709,12 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -5642,6 +5918,12 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -5847,6 +6129,12 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -5924,7 +6212,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -5952,6 +6240,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -6845,6 +7134,74 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -6953,6 +7310,9 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -6968,7 +7328,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.0909091);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.0882353);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.1. Title Content Slide some content footer content 4 </div>
@@ -7188,6 +7548,12 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -7392,6 +7758,12 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -7595,6 +7967,12 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -7800,6 +8178,12 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -7877,7 +8261,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -7905,6 +8289,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -8796,6 +9181,74 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -8904,6 +9357,9 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -8919,7 +9375,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.121212);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.117647);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.1. Title Image Slide footer content 5 </div>
@@ -9139,6 +9595,12 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -9343,6 +9805,12 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -9546,6 +10014,12 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -9751,6 +10225,12 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -9828,7 +10308,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -9856,6 +10336,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -10745,6 +11226,74 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -10853,6 +11402,9 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -10868,7 +11420,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.151515);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.147059);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.1. Title Image Slide to test image description &amp; credit Source: https://www.example.com footer content 6 </div>
@@ -11088,6 +11640,12 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -11292,6 +11850,12 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -11495,6 +12059,12 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -11700,6 +12270,12 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -11777,7 +12353,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -11805,6 +12381,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -12692,6 +13269,74 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -12800,6 +13445,9 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -12815,7 +13463,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.181818);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.176471);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.1. Title Image Slide to test image credit Source: https://www.example.com footer content 7 </div>
@@ -13035,6 +13683,12 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -13239,6 +13893,12 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -13442,6 +14102,12 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -13647,6 +14313,12 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -13724,7 +14396,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -13752,6 +14424,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -14637,6 +15310,74 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -14745,6 +15486,9 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -14760,7 +15504,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.212121);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.205882);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.1. Title Image Slide to test image credit without value footer content 8 </div>
@@ -14980,6 +15724,12 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -15184,6 +15934,12 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -15387,6 +16143,12 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -15592,6 +16354,12 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -15669,7 +16437,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -15697,6 +16465,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -16580,6 +17349,74 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -16688,6 +17525,9 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -16703,7 +17543,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.242424);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.235294);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.1. Title Image Slide to test invalid image metadata footer content 9 </div>
@@ -16923,6 +17763,12 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -17127,6 +17973,12 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -17330,6 +18182,12 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -17535,6 +18393,12 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -17612,7 +18476,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -17640,6 +18504,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -18521,6 +19386,74 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -18629,6 +19562,9 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -18644,7 +19580,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.272727);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.264706);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.2. Title Content Image Slide some content footer content 10 </div>
@@ -18864,6 +19800,12 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -19068,6 +20010,12 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -19271,6 +20219,12 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -19476,6 +20430,12 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -19553,7 +20513,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -19581,6 +20541,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -20460,6 +21421,74 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -20568,6 +21597,9 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -20583,7 +21615,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.30303);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.294118);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.3. Title Content Image Slide - scale down font this line should be visible Lorem ipsum dolor sit amet consectetur adipisicing elit sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. this line should be visible footer content 11 </div>
@@ -20803,6 +21835,12 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -21007,6 +22045,12 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -21210,6 +22254,12 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -21415,6 +22465,12 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -21492,7 +22548,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -21520,6 +22576,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -22399,6 +23456,74 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -22507,6 +23632,9 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -22522,7 +23650,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.333333);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.323529);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">This is some content. </div>
@@ -22742,6 +23870,12 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -22946,6 +24080,12 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -23149,6 +24289,12 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -23354,6 +24500,12 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -23431,7 +24583,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -23459,6 +24611,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -24338,6 +25491,74 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -24446,6 +25667,9 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -24461,7 +25685,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.363636);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.352941);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">some content </div>
@@ -24681,6 +25905,12 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -24885,6 +26115,12 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -25088,6 +26324,12 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -25293,6 +26535,12 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -25370,7 +26618,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -25398,6 +26646,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -26278,6 +27527,74 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -26386,6 +27703,9 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -26401,7 +27721,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.393939);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.382353);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">2. Section Slide for long TOC footer content 14 </div>
@@ -26621,6 +27941,12 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -26825,6 +28151,12 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -27028,6 +28360,12 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -27233,6 +28571,12 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -27310,7 +28654,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -27338,6 +28682,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -28219,6 +29564,74 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -28327,6 +29740,9 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -28342,7 +29758,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.424242);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.411765);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">3. Section Slide for long TOC footer content 15 </div>
@@ -28562,6 +29978,12 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -28766,6 +30188,12 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -28969,6 +30397,12 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -29174,6 +30608,12 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -29251,7 +30691,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -29279,6 +30719,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -30161,6 +31602,74 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -30269,6 +31778,9 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -30284,7 +31796,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.454545);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.441176);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">4. Section Slide for long TOC footer content 16 </div>
@@ -30504,6 +32016,12 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -30708,6 +32226,12 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -30911,6 +32435,12 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -31116,6 +32646,12 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -31193,7 +32729,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -31221,6 +32757,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -32104,6 +33641,74 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -32212,6 +33817,9 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -32227,7 +33835,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.484848);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.470588);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">5. Section Slide for long TOC footer content 17 </div>
@@ -32447,6 +34055,12 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -32651,6 +34265,12 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -32854,6 +34474,12 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -33059,6 +34685,12 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -33136,7 +34768,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -33164,6 +34796,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -34048,6 +35681,74 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -34156,6 +35857,9 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -34171,7 +35875,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.515152);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.5);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">6. Section Slide for long TOC footer content 18 </div>
@@ -34391,6 +36095,12 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -34595,6 +36305,12 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -34798,6 +36514,12 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -35003,6 +36725,12 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -35080,7 +36808,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -35108,6 +36836,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -35993,6 +37722,74 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -36101,6 +37898,9 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -36116,7 +37916,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.545455);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.529412);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">7. Section Slide for long TOC footer content 19 </div>
@@ -36336,6 +38136,12 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -36540,6 +38346,12 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -36743,6 +38555,12 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -36948,6 +38766,12 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -37025,7 +38849,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -37053,6 +38877,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -37939,6 +39764,74 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -38047,6 +39940,9 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -38062,7 +39958,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.575758);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.558824);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">8. Section Slide for long TOC footer content 20 </div>
@@ -38282,6 +40178,12 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -38486,6 +40388,12 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -38689,6 +40597,12 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -38894,6 +40808,12 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -38971,7 +40891,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -38999,6 +40919,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -39886,6 +41807,74 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -39994,6 +41983,9 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -40009,7 +42001,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.606061);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.588235);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">9. Section Slide for long TOC footer content 21 </div>
@@ -40229,6 +42221,12 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -40433,6 +42431,12 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -40636,6 +42640,12 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -40841,6 +42851,12 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -40918,7 +42934,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -40946,6 +42962,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -41834,6 +43851,74 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -41942,6 +44027,9 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -41957,7 +44045,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.636364);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.617647);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">10. Section Slide for long TOC footer content 22 </div>
@@ -42177,6 +44265,12 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -42381,6 +44475,12 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -42584,6 +44684,12 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -42789,6 +44895,12 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -42866,7 +44978,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -42894,6 +45006,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -43783,6 +45896,74 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -43891,6 +46072,9 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -43906,7 +46090,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.666667);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.647059);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">11. Section Slide for long TOC footer content 23 </div>
@@ -44126,6 +46310,12 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -44330,6 +46520,12 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -44533,6 +46729,12 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -44738,6 +46940,12 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -44815,7 +47023,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -44843,6 +47051,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -45733,6 +47942,74 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -45841,6 +48118,9 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -45856,7 +48136,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.69697);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.676471);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">12. Section Slide for long TOC footer content 24 </div>
@@ -46076,6 +48356,12 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -46280,6 +48566,12 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -46483,6 +48775,12 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -46688,6 +48986,12 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -46765,7 +49069,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -46793,6 +49097,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -47684,6 +49989,74 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -47792,6 +50165,9 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -47807,7 +50183,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.727273);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.705882);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">13. Section Slide for long TOC footer content 25 </div>
@@ -48027,6 +50403,12 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -48231,6 +50613,12 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -48434,6 +50822,12 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -48639,6 +51033,12 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -48716,7 +51116,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -48744,6 +51144,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -49636,6 +52037,74 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -49744,6 +52213,9 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -49759,7 +52231,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.757576);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.735294);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">14. Section Slide for long TOC footer content 26 </div>
@@ -49979,6 +52451,12 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -50183,6 +52661,12 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -50386,6 +52870,12 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -50591,6 +53081,12 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -50668,7 +53164,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -50696,6 +53192,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -51589,6 +54086,74 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -51697,6 +54262,9 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -51712,7 +54280,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.787879);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.764706);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">15. Section Slide for long TOC footer content 27 </div>
@@ -51932,6 +54500,12 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -52136,6 +54710,12 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -52339,6 +54919,12 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -52544,6 +55130,12 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -52621,7 +55213,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -52649,6 +55241,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -53543,6 +56136,74 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -53651,6 +56312,9 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -53666,7 +56330,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.818182);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.794118);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">16. Section Slide for long TOC footer content 28 </div>
@@ -53886,6 +56550,12 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -54090,6 +56760,12 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -54293,6 +56969,12 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -54498,6 +57180,12 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -54575,7 +57263,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -54603,6 +57291,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -55498,6 +58187,74 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -55606,6 +58363,9 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -55621,7 +58381,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.848485);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.823529);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">17. Section Slide for long TOC footer content 29 </div>
@@ -55841,6 +58601,12 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -56045,6 +58811,12 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -56248,6 +59020,12 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -56453,6 +59231,12 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -56530,7 +59314,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -56558,6 +59342,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -57454,6 +60239,74 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -57562,6 +60415,9 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -57577,7 +60433,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.878788);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.852941);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">18. Section Slide for long TOC footer content 30 </div>
@@ -57797,6 +60653,12 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -58001,6 +60863,12 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -58204,6 +61072,12 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -58409,6 +61283,12 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -58486,7 +61366,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -58514,6 +61394,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -59411,6 +62292,74 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -59519,6 +62468,9 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -59534,7 +62486,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.909091);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.882353);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">19. Section Slide for long TOC footer content 31 </div>
@@ -59754,6 +62706,12 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -59958,6 +62916,12 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -60161,6 +63125,12 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -60366,6 +63336,12 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -60443,7 +63419,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -60471,6 +63447,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -61369,6 +64346,74 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -61477,6 +64522,9 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
             <div class="slide-background title-content future" style="display: block;" data-loaded="true">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -61492,7 +64540,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.939394);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.911765);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">20. Section Slide for long TOC footer content 32 </div>
@@ -61712,6 +64760,12 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -61916,6 +64970,12 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -62119,6 +65179,12 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -62324,6 +65390,12 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -62401,7 +65473,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -62429,6 +65501,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -63328,6 +66401,74 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -63436,6 +66577,9 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
             <div class="slide-background title-content future" style="display: block;" data-loaded="true">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: block;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -63451,7 +66595,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.969697);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.941176);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">21. Section Slide for long TOC footer content 33 </div>
@@ -63671,6 +66815,12 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -63875,6 +67025,12 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -64078,6 +67234,12 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -64283,6 +67445,12 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -64360,7 +67528,7 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 18px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -64388,6 +67556,7 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                                 <li>Section Slide for long TOC</li>
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -65285,6 +68454,74 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Support for alerts
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -65393,12 +68630,15 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
             <div class="slide-background title-content present" style="display: block;" data-loaded="true">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: block;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
                 <div class="controls-arrow"></div>
             </button>
-            <button class="navigate-right" aria-label="next slide" disabled="disabled">
+            <button class="navigate-right enabled" aria-label="next slide">
                 <div class="controls-arrow"></div>
             </button>
             <button class="navigate-up" aria-label="above slide" disabled="disabled">
@@ -65408,7 +68648,7 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(1);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.970588);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">21.1. Mermaid JS #mermaid-unique-id{font-family:"trebuchet ms",verdana,arial,sans-serif;font-size:16px;fill:#333;}#mermaid-unique-id .error-icon{fill:#552222;}#mermaid-unique-id .error-text{fill:#552222;stroke:#552222;}#mermaid-unique-id .edge-thickness-normal{stroke-width:2px;}#mermaid-unique-id .edge-thickness-thick{stroke-width:3.5px;}#mermaid-unique-id .edge-pattern-solid{stroke-dasharray:0;}#mermaid-unique-id .edge-pattern-dashed{stroke-dasharray:3;}#mermaid-unique-id .edge-pattern-dotted{stroke-dasharray:2;}#mermaid-unique-id .marker{fill:#333333;stroke:#333333;}#mermaid-unique-id .marker.cross{stroke:#333333;}#mermaid-unique-id svg{font-family:"trebuchet ms",verdana,arial,sans-serif;font-size:16px;}#mermaid-unique-id .label{font-family:"trebuchet ms",verdana,arial,sans-serif;color:#333;}#mermaid-unique-id .cluster-label text{fill:#333;}#mermaid-unique-id .cluster-label span,#mermaid-unique-id p{color:#333;}#mermaid-unique-id .label text,#mermaid-unique-id span,#mermaid-unique-id p{fill:#333;color:#333;}#mermaid-unique-id .node rect,#mermaid-unique-id .node circle,#mermaid-unique-id .node ellipse,#mermaid-unique-id .node polygon,#mermaid-unique-id .node path{fill:#ECECFF;stroke:#9370DB;stroke-width:1px;}#mermaid-unique-id .flowchart-label text{text-anchor:middle;}#mermaid-unique-id .node .label{text-align:center;}#mermaid-unique-id .node.clickable{cursor:pointer;}#mermaid-unique-id .arrowheadPath{fill:#333333;}#mermaid-unique-id .edgePath .path{stroke:#333333;stroke-width:2.0px;}#mermaid-unique-id .flowchart-link{stroke:#333333;fill:none;}#mermaid-unique-id .edgeLabel{background-color:#e8e8e8;text-align:center;}#mermaid-unique-id .edgeLabel rect{opacity:0.5;background-color:#e8e8e8;fill:#e8e8e8;}#mermaid-unique-id .labelBkg{background-color:rgba(232, 232, 232, 0.5);}#mermaid-unique-id .cluster rect{fill:#ffffde;stroke:#aaaa33;stroke-width:1px;}#mermaid-unique-id .cluster text{fill:#333;}#mermaid-unique-id .cluster span,#mermaid-unique-id p{color:#333;}#mermaid-unique-id div.mermaidTooltip{position:absolute;text-align:center;max-width:200px;padding:2px;font-family:"trebuchet ms",verdana,arial,sans-serif;font-size:12px;background:hsl(80, 100%, 96.2745098039%);border:1px solid #aaaa33;border-radius:2px;pointer-events:none;z-index:100;}#mermaid-unique-id .flowchartTitleText{text-anchor:middle;font-size:18px;fill:#333;}#mermaid-unique-id :root{--mermaid-unique-id:"trebuchet ms",verdana,arial,sans-serif;} Yes No Start Is it? OK Rethink End footer content 34 </div>
@@ -65628,6 +68868,12 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -65832,6 +69078,12 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }])
             adjustFontSize()
             setFullPageBackground([{
@@ -66035,6 +69287,12 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -66240,6 +69498,2063 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                 "slide": "title-content",
                 "index": "21.1. ",
                 "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
+            }], 'markdown/test', 1123, 794)
+        })
+        Reveal.configure(config)
+        Reveal.initialize({
+            hash: true,
+
+            // Learn about plugins: https://revealjs.com/plugins/
+            plugins: [RevealAwesoMD, RevealHighlight, RevealNotes, RevealMermaid],
+        })
+    </script>
+    <script src="//localhost:35729/livereload.js?snipver=1" async="" defer=""></script>
+
+</body>
+
+</html>"
+`;
+
+exports[`test markdown presentation should render markdown presentation 35`] = `
+"<!DOCTYPE html>
+<html lang="en" class="reveal-full-page">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+    <title>footer content</title>
+
+    <link rel="stylesheet" href="dist/css/vendor.css">
+    <link rel="stylesheet" href="dist/css/metadata.css">
+    <style type="text/css">
+        .hljs-ln {
+            border-collapse: collapse
+        }
+
+        .hljs-ln td {
+            padding: 0
+        }
+
+        .hljs-ln-n:before {
+            content: attr(data-line-number)
+        }
+    </style>
+</head>
+
+<body class="reveal-viewport" style="--slide-width: 960px; --slide-height: 700px; --slide-scale: 1.6457142857142857; --viewport-width: 1920px; --viewport-height: 1200px;">
+    <div class="reveal slide center focused has-horizontal-slides ready" role="application" data-transition-speed="default" data-background-transition="slide">
+        <div class="slides" style="width: 960px; height: 700px; inset: 50% auto auto 50%; transform: translate(-50%, -50%) scale(1.64571);">
+            <section class="op-cover past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="cover-logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
+                        </div>
+
+                        <div class="content">
+                            <h1>footer content</h1>
+                            <p>
+                                presenter name
+                                - some description
+                            </p>
+
+                        </div>
+
+                    </div>
+                </div>
+
+            </section>
+            <section class="toc past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Table of Contents
+
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                                <li>Section Slide<ol>
+                                        <li>Title Content Slide</li>
+                                        <li>Title Content Image Slide</li>
+                                        <li>Title Content Image Slide - scale down font</li>
+                                    </ol>
+                                </li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC<ol>
+                                        <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
+                                    </ol>
+                                </li>
+                            </ol>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">2</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">1. </h1>
+                            <h1 class="title">
+                                Section Slide
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">3</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.1. Title Content Slide</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p>some content</p>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">4</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.1. Title Image Slide</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p class="image-container">
+                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                <div class="image-credit">
+                                    <p></p>
+                                </div>
+                            </div>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">5</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.1. Title Image Slide to test image description &amp; credit</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p class="image-container">
+                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                <div class="image-credit">
+                                    <p>Source: https://www.example.com</p>
+                                </div>
+                            </div>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">6</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.1. Title Image Slide to test image credit</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p class="image-container">
+                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                <div class="image-credit">
+                                    <p>Source: https://www.example.com</p>
+                                </div>
+                            </div>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">7</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.1. Title Image Slide to test image credit without value</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p class="image-container">
+                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                <div class="image-credit">
+                                    <p></p>
+                                </div>
+                            </div>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">8</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.1. Title Image Slide to test invalid image metadata</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p class="image-container">
+                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                <div class="image-credit">
+                                    <p></p>
+                                </div>
+                            </div>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">9</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content-image past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.2. Title Content Image Slide</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p>some content</p>
+                            <p class="image-container">
+                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                <div class="image-credit">
+                                    <p></p>
+                                </div>
+                            </div>
+                            </p>
+                        </div>
+                    </div>
+
+                    <footer>
+                        <div class="footer-item footer-title">
+                            <p>footer content</p>
+                        </div>
+                        <div class="footer-item custom-slide-number">10</div>
+                        <div class="footer-item footer-logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
+                        </div>
+                    </footer>
+
+                </div>
+            </section>
+            <section class="title-content-image past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.3. Title Content Image Slide - scale down font</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
+                            <ul style="font-size: 11px; margin-top: 0px; margin-bottom: 0px;">
+                                <li>Lorem</li>
+                                <li>ipsum</li>
+                                <li>dolor</li>
+                                <li>sit</li>
+                                <li>amet</li>
+                                <li>consectetur</li>
+                                <li>adipisicing</li>
+                                <li>elit</li>
+                                <li>sed</li>
+                                <li>eiusmod</li>
+                                <li>tempor</li>
+                                <li>incidunt</li>
+                                <li>ut</li>
+                                <li>labore</li>
+                                <li>et</li>
+                                <li>dolore</li>
+                                <li>magna</li>
+                                <li>aliqua.</li>
+                                <li>Ut</li>
+                                <li>enim</li>
+                                <li>ad</li>
+                                <li>minim</li>
+                                <li>veniam</li>
+                            </ul>
+                            <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                            <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
+                            <p class="image-container">
+                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-credit">
+                                    <p></p>
+                                </div>
+                            </div>
+                            </p>
+                        </div>
+                    </div>
+
+                    <footer>
+                        <div class="footer-item footer-title">
+                            <p>footer content</p>
+                        </div>
+                        <div class="footer-item custom-slide-number">11</div>
+                        <div class="footer-item footer-logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
+                        </div>
+                    </footer>
+
+                </div>
+            </section>
+            <section class="image past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p>This is some content.</p>
+                        </div>
+                    </div>
+                </div>
+
+            </section>
+            <section class="image past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p>some content</p>
+                        </div>
+                    </div>
+                </div>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">2. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">3. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">4. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">5. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">6. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">7. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">19</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">8. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">20</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">9. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">21</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">10. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">22</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">11. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">23</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">12. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">24</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">13. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">25</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">14. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">26</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">15. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">27</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">16. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">28</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">17. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">29</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">18. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">30</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">19. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">20. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">21. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">21.1. Mermaid JS</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <pre class="code-wrapper"><code class="mermaid hljs language-css" data-highlighted="yes"><svg aria-roledescription="flowchart-v2" role="graphics-document document" viewBox="-8 -8 160.78515625 451.796875" style="max-width: 160.78515625px;" xmlns="http://www.w3.org/2000/svg" width="100%" id="mermaid-unique-id"><style>#mermaid-unique-id{font-family:"trebuchet ms",verdana,arial,sans-serif;font-size:16px;fill:#333;}#mermaid-unique-id .error-icon{fill:#552222;}#mermaid-unique-id .error-text{fill:#552222;stroke:#552222;}#mermaid-unique-id .edge-thickness-normal{stroke-width:2px;}#mermaid-unique-id .edge-thickness-thick{stroke-width:3.5px;}#mermaid-unique-id .edge-pattern-solid{stroke-dasharray:0;}#mermaid-unique-id .edge-pattern-dashed{stroke-dasharray:3;}#mermaid-unique-id .edge-pattern-dotted{stroke-dasharray:2;}#mermaid-unique-id .marker{fill:#333333;stroke:#333333;}#mermaid-unique-id .marker.cross{stroke:#333333;}#mermaid-unique-id svg{font-family:"trebuchet ms",verdana,arial,sans-serif;font-size:16px;}#mermaid-unique-id .label{font-family:"trebuchet ms",verdana,arial,sans-serif;color:#333;}#mermaid-unique-id .cluster-label text{fill:#333;}#mermaid-unique-id .cluster-label span,#mermaid-unique-id p{color:#333;}#mermaid-unique-id .label text,#mermaid-unique-id span,#mermaid-unique-id p{fill:#333;color:#333;}#mermaid-unique-id .node rect,#mermaid-unique-id .node circle,#mermaid-unique-id .node ellipse,#mermaid-unique-id .node polygon,#mermaid-unique-id .node path{fill:#ECECFF;stroke:#9370DB;stroke-width:1px;}#mermaid-unique-id .flowchart-label text{text-anchor:middle;}#mermaid-unique-id .node .label{text-align:center;}#mermaid-unique-id .node.clickable{cursor:pointer;}#mermaid-unique-id .arrowheadPath{fill:#333333;}#mermaid-unique-id .edgePath .path{stroke:#333333;stroke-width:2.0px;}#mermaid-unique-id .flowchart-link{stroke:#333333;fill:none;}#mermaid-unique-id .edgeLabel{background-color:#e8e8e8;text-align:center;}#mermaid-unique-id .edgeLabel rect{opacity:0.5;background-color:#e8e8e8;fill:#e8e8e8;}#mermaid-unique-id .labelBkg{background-color:rgba(232, 232, 232, 0.5);}#mermaid-unique-id .cluster rect{fill:#ffffde;stroke:#aaaa33;stroke-width:1px;}#mermaid-unique-id .cluster text{fill:#333;}#mermaid-unique-id .cluster span,#mermaid-unique-id p{color:#333;}#mermaid-unique-id div.mermaidTooltip{position:absolute;text-align:center;max-width:200px;padding:2px;font-family:"trebuchet ms",verdana,arial,sans-serif;font-size:12px;background:hsl(80, 100%, 96.2745098039%);border:1px solid #aaaa33;border-radius:2px;pointer-events:none;z-index:100;}#mermaid-unique-id .flowchartTitleText{text-anchor:middle;font-size:18px;fill:#333;}#mermaid-unique-id :root{--mermaid-unique-id:"trebuchet ms",verdana,arial,sans-serif;}</style><g><marker orient="auto" markerHeight="12" markerWidth="12" markerUnits="userSpaceOnUse" refY="5" refX="6" viewBox="0 0 10 10" class="marker flowchart" id="mermaid-unique-id"><path style="stroke-width: 1; stroke-dasharray: 1, 0;" class="arrowMarkerPath" d="M 0 0 L 10 5 L 0 10 z"></path></marker><marker orient="auto" markerHeight="12" markerWidth="12" markerUnits="userSpaceOnUse" refY="5" refX="4.5" viewBox="0 0 10 10" class="marker flowchart" id="mermaid-unique-id"><path style="stroke-width: 1; stroke-dasharray: 1, 0;" class="arrowMarkerPath" d="M 0 5 L 10 10 L 10 0 z"></path></marker><marker orient="auto" markerHeight="11" markerWidth="11" markerUnits="userSpaceOnUse" refY="5" refX="11" viewBox="0 0 10 10" class="marker flowchart" id="mermaid-unique-id"><circle style="stroke-width: 1; stroke-dasharray: 1, 0;" class="arrowMarkerPath" r="5" cy="5" cx="5"></circle></marker><marker orient="auto" markerHeight="11" markerWidth="11" markerUnits="userSpaceOnUse" refY="5" refX="-1" viewBox="0 0 10 10" class="marker flowchart" id="mermaid-unique-id"><circle style="stroke-width: 1; stroke-dasharray: 1, 0;" class="arrowMarkerPath" r="5" cy="5" cx="5"></circle></marker><marker orient="auto" markerHeight="11" markerWidth="11" markerUnits="userSpaceOnUse" refY="5.2" refX="12" viewBox="0 0 11 11" class="marker cross flowchart" id="mermaid-unique-id"><path style="stroke-width: 2; stroke-dasharray: 1, 0;" class="arrowMarkerPath" d="M 1,1 l 9,9 M 10,1 l -9,9"></path></marker><marker orient="auto" markerHeight="11" markerWidth="11" markerUnits="userSpaceOnUse" refY="5.2" refX="-1" viewBox="0 0 11 11" class="marker cross flowchart" id="mermaid-unique-id"><path style="stroke-width: 2; stroke-dasharray: 1, 0;" class="arrowMarkerPath" d="M 1,1 l 9,9 M 10,1 l -9,9"></path></marker><g class="root"><g class="clusters"></g><g class="edgePaths"><path marker-end="url(#mermaid-unique-id)" style="fill:none;" class="edge-thickness-normal edge-pattern-solid flowchart-link LS-A LE-B" id="L-A-B-0" d="M73.125,31L73.125,35.167C73.125,39.333,73.125,47.667,73.191,55.2C73.257,62.734,73.389,69.467,73.455,72.834L73.521,76.201"></path><path marker-end="url(#mermaid-unique-id)" style="fill:none;" class="edge-thickness-normal edge-pattern-solid flowchart-link LS-B LE-C" id="L-B-C-0" d="M56.635,144.307L50.373,152.556C44.111,160.804,31.587,177.3,25.325,190.165C19.063,203.03,19.063,212.264,19.063,216.88L19.063,221.497"></path><path marker-end="url(#mermaid-unique-id)" style="fill:none;" class="edge-thickness-normal edge-pattern-solid flowchart-link LS-C LE-D" id="L-C-D-0" d="M19.063,257.797L19.063,263.297C19.063,268.797,19.063,279.797,21.698,290.025C24.333,300.254,29.604,309.711,32.239,314.439L34.875,319.167"></path><path marker-end="url(#mermaid-unique-id)" style="fill:none;" class="edge-thickness-normal edge-pattern-solid flowchart-link LS-D LE-B" id="L-D-B-0" d="M54.733,323.797L57.798,318.297C60.863,312.797,66.994,301.797,70.06,288.214C73.125,274.63,73.125,258.464,73.125,242.297C73.125,226.13,73.125,209.964,73.195,197.347C73.264,184.73,73.404,175.663,73.474,171.13L73.543,166.596"></path><path marker-end="url(#mermaid-unique-id)" style="fill:none;" class="edge-thickness-normal edge-pattern-solid flowchart-link LS-B LE-E" id="L-B-E-0" d="M89.843,145.079L95.378,153.199C100.912,161.318,111.982,177.558,117.516,193.761C123.051,209.964,123.051,226.13,123.051,242.297C123.051,258.464,123.051,274.63,123.051,290.797C123.051,306.964,123.051,323.13,123.051,337.964C123.051,352.797,123.051,366.297,123.051,376.33C123.051,386.364,123.051,392.93,123.051,396.214L123.051,399.497"></path></g><g class="edgeLabels"><g class="edgeLabel"><g transform="translate(0, 0)" class="label"><foreignObject height="0" width="0"><div style="display: inline-block; white-space: nowrap;" xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel"></span></div></foreignObject></g></g><g transform="translate(19.0625, 193.796875)" class="edgeLabel"><g transform="translate(-13.0546875, -8)" class="label"><foreignObject height="16" width="26.109375"><div style="display: inline-block; white-space: nowrap;" xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel">Yes</span></div></foreignObject></g></g><g class="edgeLabel"><g transform="translate(0, 0)" class="label"><foreignObject height="0" width="0"><div style="display: inline-block; white-space: nowrap;" xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel"></span></div></foreignObject></g></g><g class="edgeLabel"><g transform="translate(0, 0)" class="label"><foreignObject height="0" width="0"><div style="display: inline-block; white-space: nowrap;" xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel"></span></div></foreignObject></g></g><g transform="translate(123.05078125, 290.796875)" class="edgeLabel"><g transform="translate(-10.2265625, -8)" class="label"><foreignObject height="16" width="20.453125"><div style="display: inline-block; white-space: nowrap;" xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel">No</span></div></foreignObject></g></g></g><g class="nodes"><g transform="translate(73.125, 15.5)" data-id="A" data-node="true" id="flowchart-A-0" class="node default default flowchart-label"><rect height="31" width="48.796875" y="-15.5" x="-24.3984375" ry="0" rx="0" style="" class="basic label-container"></rect><g transform="translate(-16.8984375, -8)" style="" class="label"><rect></rect><foreignObject height="16" width="33.796875"><div style="display: inline-block; white-space: nowrap;" xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Start</span></div></foreignObject></g></g><g transform="translate(73.125, 120.8984375)" data-id="B" data-node="true" id="flowchart-B-1" class="node default default flowchart-label"><polygon style="" transform="translate(-39.8984375,39.8984375)" class="label-container" points="39.8984375,0 79.796875,-39.8984375 39.8984375,-79.796875 0,-39.8984375"></polygon><g transform="translate(-16.8984375, -8)" style="" class="label"><rect></rect><foreignObject height="16" width="33.796875"><div style="display: inline-block; white-space: nowrap;" xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Is it?</span></div></foreignObject></g></g><g transform="translate(19.0625, 242.296875)" data-id="C" data-node="true" id="flowchart-C-3" class="node default default flowchart-label"><rect height="31" width="38.125" y="-15.5" x="-19.0625" ry="0" rx="0" style="" class="basic label-container"></rect><g transform="translate(-11.5625, -8)" style="" class="label"><rect></rect><foreignObject height="16" width="23.125"><div style="display: inline-block; white-space: nowrap;" xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">OK</span></div></foreignObject></g></g><g transform="translate(46.09375, 339.296875)" data-id="D" data-node="true" id="flowchart-D-5" class="node default default flowchart-label"><rect height="31" width="69.25" y="-15.5" x="-34.625" ry="0" rx="0" style="" class="basic label-container"></rect><g transform="translate(-27.125, -8)" style="" class="label"><rect></rect><foreignObject height="16" width="54.25"><div style="display: inline-block; white-space: nowrap;" xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Rethink</span></div></foreignObject></g></g><g transform="translate(123.05078125, 420.296875)" data-id="E" data-node="true" id="flowchart-E-9" class="node default default flowchart-label"><rect height="31" width="43.46875" y="-15.5" x="-21.734375" ry="0" rx="0" style="" class="basic label-container"></rect><g transform="translate(-14.234375, -8)" style="" class="label"><rect></rect><foreignObject height="16" width="28.46875"><div style="display: inline-block; white-space: nowrap;" xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">End</span></div></foreignObject></g></g></g></g></g></svg></code></pre>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">34</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content present" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;">
+                <div class="content-container">
+                    <h1 class="title">21.2. Support for alerts</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="alert note" style="font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+                            <div class="alert caution" style="font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert" style="font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+                            <div class="alert" style="font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px; font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert caution" style="font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+        </div>
+        <div class="backgrounds">
+            <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
+                <div class="slide-background-content">
+                    <div class="image-overlay-container">
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="slide-background toc past" data-loaded="true" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" data-loaded="true" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content-image past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content-image past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background image past" style="display: none; background-image: url(&quot;markdown/test/test-16-9.png&quot;); background-repeat: no-repeat; background-size: cover; background-position: center center;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background image past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content">Please provide background image for this slide</div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: block;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: block;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content present" style="display: block;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+        </div>
+        <div class="slide-number" style="display: none;"></div>
+        <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
+                <div class="controls-arrow"></div>
+            </button>
+            <button class="navigate-right" aria-label="next slide" disabled="disabled">
+                <div class="controls-arrow"></div>
+            </button>
+            <button class="navigate-up" aria-label="above slide" disabled="disabled">
+                <div class="controls-arrow"></div>
+            </button>
+            <button class="navigate-down" aria-label="below slide" disabled="disabled">
+                <div class="controls-arrow"></div>
+            </button>
+        </aside>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(1);"></span></div>
+        <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
+        <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">21.2. Support for alerts Note Useful information that users should know, even when skimming content. Caution Advises about risks or negative outcomes of certain actions. [!something] Advises about risks or negative outcomes of certain actions. [!CAUTION] Advises about risks or negative outcomes of certain actions. [!CAUTION] Advises about risks or negative outcomes of certain actions. [!CAUTION] Advises about risks or negative outcomes of certain actions. Caution &gt; Advises about risks or negative outcomes of certain actions. footer content 35 </div>
+    </div>
+    <script src="dist/js/vendor.js"></script>
+    <script src="dist/js/utils.js"></script>
+    <script src="config-reveal.js"></script>
+    <script src="utils/helper.js"></script>
+    <script>
+        // config is defined in config-reveal.js
+        Reveal.addEventListener('ready', function(event) {
+            addBackgroundOverlay()
+            updateImageStructure()
+            updateImageUrl('markdown/test')
+            addCustomSlideNumber(event)
+            fitContent()
+            adjustFontSize()
+            showHideFooterAndSlideNumber('yes', false)
+            setFullPageBackground([{
+                "slideNumber": 2,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "1. ",
+                "headingText": "Section Slide"
+            }, {
+                "slideNumber": 3,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Content Slide"
+            }, {
+                "slideNumber": 4,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide"
+            }, {
+                "slideNumber": 5,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image description & credit"
+            }, {
+                "slideNumber": 6,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit"
+            }, {
+                "slideNumber": 7,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit without value"
+            }, {
+                "slideNumber": 8,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test invalid image metadata"
+            }, {
+                "slideNumber": 9,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.2. ",
+                "headingText": "Title Content Image Slide"
+            }, {
+                "slideNumber": 10,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.3. ",
+                "headingText": "Title Content Image Slide - scale down font"
+            }, {
+                "slideNumber": 11,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "background": "test-16-9.png",
+                "pdfbackground": "test-4-3.png",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 12,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 13,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "2. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 14,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "3. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 15,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "4. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 16,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "5. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 17,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "6. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 18,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "7. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 19,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "8. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 20,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "9. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 21,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "10. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 22,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "11. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 23,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "12. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 24,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "13. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 25,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "14. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 26,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "15. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 27,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "16. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 28,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "17. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 29,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "18. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 30,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "19. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 31,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "20. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 32,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "21. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 33,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.1. ",
+                "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
+            }], 'markdown/test', 1123, 794)
+        })
+        Reveal.addEventListener('slidechanged', function(event) {
+            setIndex([{
+                "slideNumber": 2,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "1. ",
+                "headingText": "Section Slide"
+            }, {
+                "slideNumber": 3,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Content Slide"
+            }, {
+                "slideNumber": 4,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide"
+            }, {
+                "slideNumber": 5,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image description & credit"
+            }, {
+                "slideNumber": 6,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit"
+            }, {
+                "slideNumber": 7,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit without value"
+            }, {
+                "slideNumber": 8,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test invalid image metadata"
+            }, {
+                "slideNumber": 9,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.2. ",
+                "headingText": "Title Content Image Slide"
+            }, {
+                "slideNumber": 10,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.3. ",
+                "headingText": "Title Content Image Slide - scale down font"
+            }, {
+                "slideNumber": 11,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "background": "test-16-9.png",
+                "pdfbackground": "test-4-3.png",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 12,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 13,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "2. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 14,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "3. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 15,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "4. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 16,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "5. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 17,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "6. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 18,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "7. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 19,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "8. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 20,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "9. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 21,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "10. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 22,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "11. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 23,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "12. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 24,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "13. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 25,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "14. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 26,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "15. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 27,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "16. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 28,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "17. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 29,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "18. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 30,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "19. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 31,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "20. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 32,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "21. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 33,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.1. ",
+                "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
+            }])
+            adjustFontSize()
+            setFullPageBackground([{
+                "slideNumber": 2,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "1. ",
+                "headingText": "Section Slide"
+            }, {
+                "slideNumber": 3,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Content Slide"
+            }, {
+                "slideNumber": 4,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide"
+            }, {
+                "slideNumber": 5,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image description & credit"
+            }, {
+                "slideNumber": 6,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit"
+            }, {
+                "slideNumber": 7,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit without value"
+            }, {
+                "slideNumber": 8,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test invalid image metadata"
+            }, {
+                "slideNumber": 9,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.2. ",
+                "headingText": "Title Content Image Slide"
+            }, {
+                "slideNumber": 10,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.3. ",
+                "headingText": "Title Content Image Slide - scale down font"
+            }, {
+                "slideNumber": 11,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "background": "test-16-9.png",
+                "pdfbackground": "test-4-3.png",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 12,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 13,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "2. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 14,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "3. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 15,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "4. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 16,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "5. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 17,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "6. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 18,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "7. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 19,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "8. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 20,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "9. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 21,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "10. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 22,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "11. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 23,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "12. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 24,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "13. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 25,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "14. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 26,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "15. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 27,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "16. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 28,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "17. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 29,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "18. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 30,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "19. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 31,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "20. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 32,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "21. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 33,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.1. ",
+                "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
+            }], 'markdown/test', 1123, 794)
+        })
+        Reveal.addEventListener('resize', function() {
+            addBackgroundOverlay()
+            setFullPageBackground([{
+                "slideNumber": 2,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "1. ",
+                "headingText": "Section Slide"
+            }, {
+                "slideNumber": 3,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Content Slide"
+            }, {
+                "slideNumber": 4,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide"
+            }, {
+                "slideNumber": 5,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image description & credit"
+            }, {
+                "slideNumber": 6,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit"
+            }, {
+                "slideNumber": 7,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit without value"
+            }, {
+                "slideNumber": 8,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test invalid image metadata"
+            }, {
+                "slideNumber": 9,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.2. ",
+                "headingText": "Title Content Image Slide"
+            }, {
+                "slideNumber": 10,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.3. ",
+                "headingText": "Title Content Image Slide - scale down font"
+            }, {
+                "slideNumber": 11,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "background": "test-16-9.png",
+                "pdfbackground": "test-4-3.png",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 12,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 13,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "2. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 14,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "3. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 15,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "4. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 16,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "5. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 17,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "6. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 18,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "7. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 19,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "8. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 20,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "9. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 21,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "10. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 22,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "11. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 23,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "12. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 24,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "13. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 25,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "14. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 26,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "15. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 27,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "16. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 28,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "17. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 29,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "18. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 30,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "19. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 31,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "20. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 32,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "21. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 33,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.1. ",
+                "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)

--- a/tests/unit/jest/presentation.spec.js
+++ b/tests/unit/jest/presentation.spec.js
@@ -92,7 +92,7 @@ beforeEach(async () => {
 describe('test markdown presentation', () => {
     it('should match the total number of slides', async () => {
         const totalSlides = await getTotalSlides()
-        expect(totalSlides).toEqual(34)
+        expect(totalSlides).toEqual(35)
     })
 
     it('should render markdown presentation', async () => {

--- a/tests/unit/testFiles/markdown/test/test.md
+++ b/tests/unit/testFiles/markdown/test/test.md
@@ -102,3 +102,26 @@ flowchart TD
    D --> B;
    B -- No ----> E[End];
 ```
+
+## Support for alerts
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+>    [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+
+> [!something]
+> Advises about risks or negative outcomes of certain actions.
+
+> [!CAUTION]
+
+> Advises about risks or negative outcomes of certain actions.
+
+>> [!CAUTION]
+>> Advises about risks or negative outcomes of certain actions.
+
+> [!CAUTION] Advises about risks or negative outcomes of certain actions.
+
+> [!CAUTION]
+        > Advises about risks or negative outcomes of certain actions.


### PR DESCRIPTION
## Description
This PR adds the support for markdown alerts. Main functionality has been added in the plugin (https://github.com/opf/revealjs-awesoMD/pull/18).

### Input markdown with different cases:
```markdown
## Support formatting of alert boxes

> [!NOTE]
> Useful information that users should know, even when skimming content.

>    [!CAUTION]
> Advises about risks or negative outcomes of certain actions.

> [!something]
> Advises about risks or negative outcomes of certain actions.

> [!CAUTION]

> Advises about risks or negative outcomes of certain actions.

>> [!CAUTION]
>> Advises about risks or negative outcomes of certain actions.

> [!CAUTION] Advises about risks or negative outcomes of certain actions.

> [!CAUTION]
        > Advises about risks or negative outcomes of certain actions.
```

### Rendered Output
![image](https://github.com/user-attachments/assets/28d49777-622e-4c37-b17a-5412a2c0e0c4)


## Related WP
https://community.openproject.org/projects/revealjs/work_packages/60582/activity