### PR TITLE
added check for push event in main branch

### DIFF
--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -43,6 +43,7 @@ throw_if_empty "1 (user name) and ENV[NEXTCLOUD_USERNAME]" $USER
 throw_if_empty "2 (password) and ENV[NEXTCLOUD_APP_ACCESS_KEY]" $PASS
 throw_if_empty "ENV[NEXTCLOUD_UPLOAD_FINAL_FOLDER]" $NEXTCLOUD_UPLOAD_FINAL_FOLDER
 throw_if_empty "ENV[NEXTCLOUD_UPLOAD_TEMP_FOLDER]" $NEXTCLOUD_UPLOAD_TEMP_FOLDER
+throw_if_empty "ENV[DEFAULT_BRANCH]" $DEFAULT_BRANCH
 
 function get_folder_path() {
   local FOLDER_PATH="$1"
@@ -97,6 +98,8 @@ do
     fi
     temp_filename=$(get_file_prefix "$GITHUB_HEAD_REF")
     destination="$(get_folder_path "$NEXTCLOUD_UPLOAD_TEMP_FOLDER")/${temp_filename}"
+  elif [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/$DEFAULT_BRANCH" ]; then
+    destination="$(get_folder_path "$NEXTCLOUD_UPLOAD_FINAL_FOLDER")/${filename}"
   else
     delete_temp_pdf
     destination="$(get_folder_path "$NEXTCLOUD_UPLOAD_FINAL_FOLDER")/${filename}"


### PR DESCRIPTION
## Description
~While working on this WP https://community.openproject.org/projects/revealjs/work_packages/60571/activity, there was part of code added to throw proper error message and the following check was added while deleting temporary files form temp folder:~

~```bash~
~if [ "$resp_code" != "204" ]; then~
~  echo "Error: Failed to delete file $temp_filename."~
~fi~
~```~

Updated: 
Actual failure occurred because the regex didn't match in the following code snippet:
```bash
commit_subject=$(git log -1 --pretty=format:%s)
  regex='Merge pull request #[0-9]+ from opf/(.+)$'
  [[ $commit_subject =~ $regex ]]
```

Because of this when a direct commit is pushed in the main branch it tried to delete a temporary file which does not exist resulting in the upload step to fail with following log:

```console
filename=layout-template.pdf
+ '[' push = pull_request ']'
+ delete_temp_pdf
++ git log -1 --pretty=format:%s
+ commit_subject='check files and permissions'
+ regex='Merge pull request #[0-9]+ from opf/(.+)$'
+ [[ check files and permissions =~ Merge pull request #[0-9]+ from opf/(.+)$ ]]
Error: Process completed with exit code 1.
```

So, added an extra check for the github event, whether the event is an direct commit on the main branch.