### PR TITLE
add image annotation

### DIFF
--- a/css/metadata.scss
+++ b/css/metadata.scss
@@ -174,6 +174,12 @@ $default-font-size: 22px;
                     margin: 0;
                 }
             }
+
+            canvas {
+                width: 100%;
+                height: auto;
+                display: block;
+            }
         }
     }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,17 +69,19 @@ gulp.task('browserifyUtils', () => browserifyUtils())
 function renderIndexHTML(folderName, rawMarkdown) {
     const fmt = utils.extractFrontmatter(rawMarkdown)
     const headingData = utils.getHeadingData(rawMarkdown)
+    const [markdown, imageAnnotationData] = utils.getImageAnnotationData(rawMarkdown)
 
     gulp.src('index.example.html')
         .pipe(
             mustache({
-                md_content: rawMarkdown,
+                md_content: markdown,
                 headingData: JSON.stringify(headingData),
                 presentation_title: fmt[1].metadata.footer,
                 imagePath: `${presentationsRoot}/${folderName}`,
                 slideNumber: fmt[1].metadata.slidenumber ?? 'yes',
                 hideFooter: fmt[1].metadata.footer === undefined || fmt[1].metadata.footer === null,
                 config: config,
+                imageAnnotationData: JSON.stringify(imageAnnotationData),
             })
         )
         .pipe(rename('index.html'))

--- a/index.example.html
+++ b/index.example.html
@@ -26,6 +26,7 @@
             Reveal.addEventListener('ready', function (event) {
                 addBackgroundOverlay()
                 updateImageStructure()
+                annotateImage({{{ imageAnnotationData }}})
                 updateImageUrl('{{{ imagePath }}}')
                 addCustomSlideNumber(event)
                 // only trigger removeText() function while opening static html file
@@ -39,6 +40,7 @@
             })
             Reveal.addEventListener('slidechanged', function (event) {
                 setIndex({{{ headingData }}})
+                annotateImage({{{ imageAnnotationData }}})
                 adjustFontSize()
                 setFullPageBackground({{{ headingData }}}, '{{{ imagePath }}}', {{ config.pdfWidth }}, {{ config.pdfHeight }})
             })

--- a/tests/unit/gulpfile.js
+++ b/tests/unit/gulpfile.js
@@ -21,17 +21,19 @@ const presentationsRoot = env.parsed.PRESENTATIONS_ROOT || 'markdown'
 function renderIndexHTML(folderName, rawMarkdown) {
     const fmt = utils.extractFrontmatter(rawMarkdown)
     const headingData = utils.getHeadingData(rawMarkdown)
+    const [markdown, imageAnnotationData] = utils.getImageAnnotationData(rawMarkdown)
 
     gulp.src('testFiles/index.example.html')
         .pipe(
             mustache({
-                md_content: rawMarkdown,
+                md_content: markdown,
                 headingData: JSON.stringify(headingData),
                 presentation_title: fmt[1].metadata.footer,
                 imagePath: `${presentationsRoot}/${folderName}`,
                 slideNumber: fmt[1].metadata.slidenumber ?? 'yes',
                 hideFooter: fmt[1].metadata.footer === undefined || fmt[1].metadata.footer === null,
                 config: config,
+                imageAnnotationData: JSON.stringify(imageAnnotationData),
             })
         )
         .pipe(rename('index.html'))

--- a/tests/unit/jest/__snapshots__/presentation.spec.js.snap
+++ b/tests/unit/jest/__snapshots__/presentation.spec.js.snap
@@ -89,6 +89,7 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -1059,6 +1060,36 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover present" data-loaded="true" style="display: block;">
@@ -1170,6 +1201,9 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left" aria-label="previous slide" disabled="disabled">
@@ -1200,6 +1234,64 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -1412,6 +1504,12 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -1622,7 +1720,71 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -1831,6 +1993,12 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -2042,6 +2210,12 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -2119,7 +2293,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -2148,6 +2322,7 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -3118,6 +3293,36 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: block;">
@@ -3229,6 +3434,9 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -3244,10 +3452,10 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.0294118);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.0285714);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
-        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">Table of Contents Section Slide Title Content Slide Title Content Image Slide Title Content Image Slide - scale down font Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Mermaid JS Support for alerts footer content 2 </div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">Table of Contents Section Slide Title Content Slide Title Content Image Slide Title Content Image Slide - scale down font Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Section Slide for long TOC Mermaid JS Support for alerts Annotation footer content 2 </div>
     </div>
     <script src="dist/js/vendor.js"></script>
     <script src="dist/js/utils.js"></script>
@@ -3258,6 +3466,64 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -3470,6 +3736,12 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -3680,7 +3952,71 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -3889,6 +4225,12 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -4100,6 +4442,12 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -4177,7 +4525,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -4206,6 +4554,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -5177,6 +5526,36 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: block;">
@@ -5288,6 +5667,9 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -5303,7 +5685,7 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.0588235);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.0571429);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1. Section Slide footer content 3 </div>
@@ -5317,6 +5699,64 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -5529,6 +5969,12 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -5739,7 +6185,71 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -5948,6 +6458,12 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -6159,6 +6675,12 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -6236,7 +6758,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -6265,6 +6787,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -7234,6 +7757,36 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -7345,6 +7898,9 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -7360,7 +7916,7 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.0882353);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.0857143);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.1. Title Content Slide some content footer content 4 </div>
@@ -7374,6 +7930,64 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -7586,6 +8200,12 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -7796,7 +8416,71 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -8005,6 +8689,12 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -8216,6 +8906,12 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -8293,7 +8989,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -8322,6 +9018,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -9289,6 +9986,36 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -9400,6 +10127,9 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -9415,7 +10145,7 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.117647);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.114286);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.1. Title Image Slide footer content 5 </div>
@@ -9429,6 +10159,64 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -9641,6 +10429,12 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -9851,7 +10645,71 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -10060,6 +10918,12 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -10271,6 +11135,12 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -10348,7 +11218,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -10377,6 +11247,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -11342,6 +12213,36 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -11453,6 +12354,9 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -11468,7 +12372,7 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.147059);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.142857);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.1. Title Image Slide to test image description &amp; credit Source: https://www.example.com footer content 6 </div>
@@ -11482,6 +12386,64 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -11694,6 +12656,12 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -11904,7 +12872,71 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -12113,6 +13145,12 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -12324,6 +13362,12 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -12401,7 +13445,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -12430,6 +13474,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -13393,6 +14438,36 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -13504,6 +14579,9 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -13519,7 +14597,7 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.176471);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.171429);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.1. Title Image Slide to test image credit Source: https://www.example.com footer content 7 </div>
@@ -13533,6 +14611,64 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -13745,6 +14881,12 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -13955,7 +15097,71 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -14164,6 +15370,12 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -14375,6 +15587,12 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -14452,7 +15670,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -14481,6 +15699,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -15442,6 +16661,36 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -15553,6 +16802,9 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -15568,7 +16820,7 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.205882);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.2);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.1. Title Image Slide to test image credit without value footer content 8 </div>
@@ -15582,6 +16834,64 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -15794,6 +17104,12 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -16004,7 +17320,71 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -16213,6 +17593,12 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -16424,6 +17810,12 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -16501,7 +17893,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -16530,6 +17922,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -17489,6 +18882,36 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -17600,6 +19023,9 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -17615,7 +19041,7 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.235294);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.228571);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.1. Title Image Slide to test invalid image metadata footer content 9 </div>
@@ -17629,6 +19055,64 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -17841,6 +19325,12 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -18051,7 +19541,71 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -18260,6 +19814,12 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -18471,6 +20031,12 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -18548,7 +20114,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -18577,6 +20143,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -19534,6 +21101,36 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -19645,6 +21242,9 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -19660,7 +21260,7 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.264706);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.257143);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.2. Title Content Image Slide some content footer content 10 </div>
@@ -19674,6 +21274,64 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -19886,6 +21544,12 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -20096,7 +21760,71 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -20305,6 +22033,12 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -20516,6 +22250,12 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -20593,7 +22333,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -20622,6 +22362,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -20894,7 +22635,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -21577,6 +23318,36 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -21688,6 +23459,9 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -21703,7 +23477,7 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.294118);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.285714);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">1.3. Title Content Image Slide - scale down font this line should be visible Lorem ipsum dolor sit amet consectetur adipisicing elit sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. this line should be visible footer content 11 </div>
@@ -21717,6 +23491,64 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -21929,6 +23761,12 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -22139,7 +23977,71 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -22348,6 +24250,12 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -22559,6 +24467,12 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -22636,7 +24550,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -22665,6 +24579,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -22937,7 +24852,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -23620,6 +25535,36 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -23731,6 +25676,9 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -23746,7 +25694,7 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.323529);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.314286);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">This is some content. </div>
@@ -23760,6 +25708,64 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -23972,6 +25978,12 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -24182,7 +26194,71 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -24391,6 +26467,12 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -24602,6 +26684,12 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -24679,7 +26767,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -24708,6 +26796,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -24980,7 +27069,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -25663,6 +27752,36 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -25774,6 +27893,9 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -25789,7 +27911,7 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.352941);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.342857);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">some content </div>
@@ -25803,6 +27925,64 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -26015,6 +28195,12 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -26225,7 +28411,71 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -26434,6 +28684,12 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -26645,6 +28901,12 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -26722,7 +28984,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -26751,6 +29013,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -27023,7 +29286,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -27707,6 +29970,36 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -27818,6 +30111,9 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -27833,7 +30129,7 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.382353);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.371429);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">2. Section Slide for long TOC footer content 14 </div>
@@ -27847,6 +30143,64 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -28059,6 +30413,12 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -28269,7 +30629,71 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -28478,6 +30902,12 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -28689,6 +31119,12 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -28766,7 +31202,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -28795,6 +31231,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -29067,7 +31504,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -29752,6 +32189,36 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -29863,6 +32330,9 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -29878,7 +32348,7 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.411765);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.4);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">3. Section Slide for long TOC footer content 15 </div>
@@ -29892,6 +32362,64 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -30104,6 +32632,12 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -30314,7 +32848,71 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -30523,6 +33121,12 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -30734,6 +33338,12 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -30811,7 +33421,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -30840,6 +33450,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -31112,7 +33723,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -31798,6 +34409,36 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -31909,6 +34550,9 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -31924,7 +34568,7 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.441176);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.428571);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">4. Section Slide for long TOC footer content 16 </div>
@@ -31938,6 +34582,64 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -32150,6 +34852,12 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -32360,7 +35068,71 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -32569,6 +35341,12 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -32780,6 +35558,12 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -32857,7 +35641,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -32886,6 +35670,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -33158,7 +35943,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -33845,6 +36630,36 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -33956,6 +36771,9 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -33971,7 +36789,7 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.470588);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.457143);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">5. Section Slide for long TOC footer content 17 </div>
@@ -33985,6 +36803,64 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -34197,6 +37073,12 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -34407,7 +37289,71 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -34616,6 +37562,12 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -34827,6 +37779,12 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -34904,7 +37862,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -34933,6 +37891,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -35205,7 +38164,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -35893,6 +38852,36 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -36004,6 +38993,9 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -36019,7 +39011,7 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.5);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.485714);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">6. Section Slide for long TOC footer content 18 </div>
@@ -36033,6 +39025,64 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -36245,6 +39295,12 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -36455,7 +39511,71 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -36664,6 +39784,12 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -36875,6 +40001,12 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -36952,7 +40084,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -36981,6 +40113,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -37253,7 +40386,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -37942,6 +41075,36 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -38053,6 +41216,9 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -38068,7 +41234,7 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.529412);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.514286);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">7. Section Slide for long TOC footer content 19 </div>
@@ -38082,6 +41248,64 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -38294,6 +41518,12 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -38504,7 +41734,71 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -38713,6 +42007,12 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -38924,6 +42224,12 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -39001,7 +42307,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -39030,6 +42336,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -39302,7 +42609,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -39992,6 +43299,36 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -40103,6 +43440,9 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -40118,7 +43458,7 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.558824);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.542857);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">8. Section Slide for long TOC footer content 20 </div>
@@ -40132,6 +43472,64 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -40344,6 +43742,12 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -40554,7 +43958,71 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -40763,6 +44231,12 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -40974,6 +44448,12 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -41051,7 +44531,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -41080,6 +44560,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -41352,7 +44833,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -42043,6 +45524,36 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -42154,6 +45665,9 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -42169,7 +45683,7 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.588235);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.571429);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">9. Section Slide for long TOC footer content 21 </div>
@@ -42183,6 +45697,64 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -42395,6 +45967,12 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -42605,7 +46183,71 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -42814,6 +46456,12 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -43025,6 +46673,12 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -43102,7 +46756,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -43131,6 +46785,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -43403,7 +47058,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -44095,6 +47750,36 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -44206,6 +47891,9 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -44221,7 +47909,7 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.617647);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.6);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">10. Section Slide for long TOC footer content 22 </div>
@@ -44235,6 +47923,64 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -44447,6 +48193,12 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -44657,7 +48409,71 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -44866,6 +48682,12 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -45077,6 +48899,12 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -45154,7 +48982,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -45183,6 +49011,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -45455,7 +49284,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -46148,6 +49977,36 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -46259,6 +50118,9 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -46274,7 +50136,7 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.647059);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.628571);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">11. Section Slide for long TOC footer content 23 </div>
@@ -46288,6 +50150,64 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -46500,6 +50420,12 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -46710,7 +50636,71 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -46919,6 +50909,12 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -47130,6 +51126,12 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -47207,7 +51209,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -47236,6 +51238,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -47508,7 +51511,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -48202,6 +52205,36 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -48313,6 +52346,9 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -48328,7 +52364,7 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.676471);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.657143);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">12. Section Slide for long TOC footer content 24 </div>
@@ -48342,6 +52378,64 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -48554,6 +52648,12 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -48764,7 +52864,71 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -48973,6 +53137,12 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -49184,6 +53354,12 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -49261,7 +53437,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -49290,6 +53466,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -49562,7 +53739,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -50257,6 +54434,36 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -50368,6 +54575,9 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -50383,7 +54593,7 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.705882);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.685714);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">13. Section Slide for long TOC footer content 25 </div>
@@ -50397,6 +54607,64 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -50609,6 +54877,12 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -50819,7 +55093,71 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -51028,6 +55366,12 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -51239,6 +55583,12 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -51316,7 +55666,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -51345,6 +55695,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -51617,7 +55968,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -52313,6 +56664,36 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -52424,6 +56805,9 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -52439,7 +56823,7 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.735294);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.714286);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">14. Section Slide for long TOC footer content 26 </div>
@@ -52453,6 +56837,64 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -52665,6 +57107,12 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -52875,7 +57323,71 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -53084,6 +57596,12 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -53295,6 +57813,12 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -53372,7 +57896,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -53401,6 +57925,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -53673,7 +58198,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -54370,6 +58895,36 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -54481,6 +59036,9 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -54496,7 +59054,7 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.764706);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.742857);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">15. Section Slide for long TOC footer content 27 </div>
@@ -54510,6 +59068,64 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -54722,6 +59338,12 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -54932,7 +59554,71 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -55141,6 +59827,12 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -55352,6 +60044,12 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -55429,7 +60127,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -55458,6 +60156,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -55730,7 +60429,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -56428,6 +61127,36 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -56539,6 +61268,9 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -56554,7 +61286,7 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.794118);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.771429);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">16. Section Slide for long TOC footer content 28 </div>
@@ -56568,6 +61300,64 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -56780,6 +61570,12 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -56990,7 +61786,71 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -57199,6 +62059,12 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -57410,6 +62276,12 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -57487,7 +62359,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -57516,6 +62388,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -57788,7 +62661,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -58487,6 +63360,36 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -58598,6 +63501,9 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -58613,7 +63519,7 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.823529);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.8);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">17. Section Slide for long TOC footer content 29 </div>
@@ -58627,6 +63533,64 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -58839,6 +63803,12 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -59049,7 +64019,71 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -59258,6 +64292,12 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -59469,6 +64509,12 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -59546,7 +64592,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -59575,6 +64621,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -59847,7 +64894,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -60547,6 +65594,36 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -60658,6 +65735,9 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -60673,7 +65753,7 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.852941);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.828571);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">18. Section Slide for long TOC footer content 30 </div>
@@ -60687,6 +65767,64 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -60899,6 +66037,12 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -61109,7 +66253,71 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -61318,6 +66526,12 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -61529,6 +66743,12 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -61606,7 +66826,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -61635,6 +66855,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -61907,7 +67128,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -62608,6 +67829,36 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -62719,6 +67970,9 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -62734,7 +67988,7 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.882353);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.857143);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">19. Section Slide for long TOC footer content 31 </div>
@@ -62748,6 +68002,64 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -62960,6 +68272,12 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -63170,7 +68488,71 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -63379,6 +68761,12 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -63590,6 +68978,12 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -63667,7 +69061,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -63696,6 +69090,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -63968,7 +69363,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -64670,6 +70065,36 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -64781,6 +70206,9 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
             <div class="slide-background title-content future" style="display: none;">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -64796,7 +70224,7 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.911765);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.885714);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">20. Section Slide for long TOC footer content 32 </div>
@@ -64810,6 +70238,64 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -65022,6 +70508,12 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -65232,7 +70724,71 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -65441,6 +70997,12 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -65652,6 +71214,12 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -65729,7 +71297,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -65758,6 +71326,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -66030,7 +71599,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -66733,6 +72302,36 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -66844,6 +72443,9 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
             <div class="slide-background title-content future" style="display: block;" data-loaded="true">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -66859,7 +72461,7 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.941176);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.914286);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">21. Section Slide for long TOC footer content 33 </div>
@@ -66873,6 +72475,64 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -67085,6 +72745,12 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -67295,7 +72961,71 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -67504,6 +73234,12 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -67715,6 +73451,12 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -67792,7 +73534,7 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -67821,6 +73563,7 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -68093,7 +73836,7 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -68794,6 +74537,36 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                 </footer>
 
             </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
         </div>
         <div class="backgrounds">
             <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
@@ -68905,6 +74678,9 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
             <div class="slide-background title-content future" style="display: block;" data-loaded="true">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: block;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
@@ -68920,7 +74696,7 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(0.970588);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.942857);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">21.1. Mermaid JS #mermaid-unique-id{font-family:"trebuchet ms",verdana,arial,sans-serif;font-size:16px;fill:#333;}#mermaid-unique-id .error-icon{fill:#552222;}#mermaid-unique-id .error-text{fill:#552222;stroke:#552222;}#mermaid-unique-id .edge-thickness-normal{stroke-width:1px;}#mermaid-unique-id .edge-thickness-thick{stroke-width:3.5px;}#mermaid-unique-id .edge-pattern-solid{stroke-dasharray:0;}#mermaid-unique-id .edge-thickness-invisible{stroke-width:0;fill:none;}#mermaid-unique-id .edge-pattern-dashed{stroke-dasharray:3;}#mermaid-unique-id .edge-pattern-dotted{stroke-dasharray:2;}#mermaid-unique-id .marker{fill:#333333;stroke:#333333;}#mermaid-unique-id .marker.cross{stroke:#333333;}#mermaid-unique-id svg{font-family:"trebuchet ms",verdana,arial,sans-serif;font-size:16px;}#mermaid-unique-id p{margin:0;}#mermaid-unique-id .label{font-family:"trebuchet ms",verdana,arial,sans-serif;color:#333;}#mermaid-unique-id .cluster-label text{fill:#333;}#mermaid-unique-id .cluster-label span{color:#333;}#mermaid-unique-id .cluster-label span p{background-color:transparent;}#mermaid-unique-id .label text,#mermaid-unique-id span{fill:#333;color:#333;}#mermaid-unique-id .node rect,#mermaid-unique-id .node circle,#mermaid-unique-id .node ellipse,#mermaid-unique-id .node polygon,#mermaid-unique-id .node path{fill:#ECECFF;stroke:#9370DB;stroke-width:1px;}#mermaid-unique-id .rough-node .label text,#mermaid-unique-id .node .label text,#mermaid-unique-id .image-shape .label,#mermaid-unique-id .icon-shape .label{text-anchor:middle;}#mermaid-unique-id .node .katex path{fill:#000;stroke:#000;stroke-width:1px;}#mermaid-unique-id .rough-node .label,#mermaid-unique-id .node .label,#mermaid-unique-id .image-shape .label,#mermaid-unique-id .icon-shape .label{text-align:center;}#mermaid-unique-id .node.clickable{cursor:pointer;}#mermaid-unique-id .root .anchor path{fill:#333333!important;stroke-width:0;stroke:#333333;}#mermaid-unique-id .arrowheadPath{fill:#333333;}#mermaid-unique-id .edgePath .path{stroke:#333333;stroke-width:2.0px;}#mermaid-unique-id .flowchart-link{stroke:#333333;fill:none;}#mermaid-unique-id .edgeLabel{background-color:rgba(232,232,232, 0.8);text-align:center;}#mermaid-unique-id .edgeLabel p{background-color:rgba(232,232,232, 0.8);}#mermaid-unique-id .edgeLabel rect{opacity:0.5;background-color:rgba(232,232,232, 0.8);fill:rgba(232,232,232, 0.8);}#mermaid-unique-id .labelBkg{background-color:rgba(232, 232, 232, 0.5);}#mermaid-unique-id .cluster rect{fill:#ffffde;stroke:#aaaa33;stroke-width:1px;}#mermaid-unique-id .cluster text{fill:#333;}#mermaid-unique-id .cluster span{color:#333;}#mermaid-unique-id div.mermaidTooltip{position:absolute;text-align:center;max-width:200px;padding:2px;font-family:"trebuchet ms",verdana,arial,sans-serif;font-size:12px;background:hsl(80, 100%, 96.2745098039%);border:1px solid #aaaa33;border-radius:2px;pointer-events:none;z-index:100;}#mermaid-unique-id .flowchartTitleText{text-anchor:middle;font-size:18px;fill:#333;}#mermaid-unique-id rect.text{fill:none;stroke-width:0;}#mermaid-unique-id .icon-shape,#mermaid-unique-id .image-shape{background-color:rgba(232,232,232, 0.8);text-align:center;}#mermaid-unique-id .icon-shape p,#mermaid-unique-id .image-shape p{background-color:rgba(232,232,232, 0.8);padding:2px;}#mermaid-unique-id .icon-shape rect,#mermaid-unique-id .image-shape rect{opacity:0.5;background-color:rgba(232,232,232, 0.8);fill:rgba(232,232,232, 0.8);}#mermaid-unique-id :root{--mermaid-unique-id:"trebuchet ms",verdana,arial,sans-serif;} Yes No Start Is it? OK Rethink End footer content 34 </div>
@@ -68934,6 +74710,64 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -69146,6 +74980,12 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -69356,7 +75196,71 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -69565,6 +75469,12 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -69776,6 +75686,12 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)
@@ -69853,7 +75769,7 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <ol style="font-size: 17px; margin-top: 0px; margin-bottom: 0px;">
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
                                 <li>Section Slide<ol>
                                         <li>Title Content Slide</li>
                                         <li>Title Content Image Slide</li>
@@ -69882,6 +75798,7 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                                 <li>Section Slide for long TOC<ol>
                                         <li>Mermaid JS</li>
                                         <li>Support for alerts</li>
+                                        <li>Annotation</li>
                                     </ol>
                                 </li>
                             </ol>
@@ -70154,7 +76071,7 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
                             <div class="image-container">
-                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
                                     <div class="image-credit">
                                         <p></p>
                                     </div>
@@ -70787,37 +76704,37 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
 
 
 
-                            <div class="alert note" style="font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                            <div class="alert note" style="font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
                                 <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                                         <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
                                     </svg> Note</div>
                                 <blockquote>Useful information that users should know, even when skimming content.</blockquote>
                             </div>
 
-                            <div class="alert caution" style="font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                            <div class="alert caution" style="font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
                                 <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                                         <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
                                     </svg> Caution</div>
                                 <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
                             </div>
 
-                            <div class="alert" style="font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                            <div class="alert" style="font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
                                 <blockquote>[!something]</blockquote>
                                 <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
                             </div>
 
-                            <div class="alert" style="font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                            <div class="alert" style="font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
                                 <blockquote>
                                     <p>[!CAUTION]</p>
                                 </blockquote>
                             </div>
-                            <div class="alert" style="font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                            <div class="alert" style="font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
                                 <blockquote>
                                     <p>Advises about risks or negative outcomes of certain actions.</p>
                                 </blockquote>
                             </div>
 
-                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px; font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px; font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
                                 <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
                                     <blockquote>
                                         <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
@@ -70825,13 +76742,13 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                                 </blockquote>
                             </div>
 
-                            <div class="alert" style="font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                            <div class="alert" style="font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
                                 <blockquote>
                                     <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
                                 </blockquote>
                             </div>
 
-                            <div class="alert caution" style="font-size: 17px; margin-top: 7px; margin-bottom: 7px;">
+                            <div class="alert caution" style="font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
                                 <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                                         <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
                                     </svg> Caution</div>
@@ -70847,6 +76764,36 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                         <p>footer content</p>
                     </div>
                     <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content future" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Annotation
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="test annotation">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
                     <div class="footer-item footer-logo">
                         <img src="templates/assets/op-logo-light.png" alt="Logo">
                     </div>
@@ -70964,12 +76911,15 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
             <div class="slide-background title-content present" style="display: block;" data-loaded="true">
                 <div class="slide-background-content"></div>
             </div>
+            <div class="slide-background title-content future" style="display: block;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
         </div>
         <div class="slide-number" style="display: none;"></div>
         <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
                 <div class="controls-arrow"></div>
             </button>
-            <button class="navigate-right" aria-label="next slide" disabled="disabled">
+            <button class="navigate-right enabled" aria-label="next slide">
                 <div class="controls-arrow"></div>
             </button>
             <button class="navigate-up" aria-label="above slide" disabled="disabled">
@@ -70979,7 +76929,7 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                 <div class="controls-arrow"></div>
             </button>
         </aside>
-        <div class="progress" style="display: block;"><span style="transform: scaleX(1);"></span></div>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(0.971429);"></span></div>
         <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
         <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
         <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">21.2. Support for alerts Note Useful information that users should know, even when skimming content. Caution Advises about risks or negative outcomes of certain actions. [!something] Advises about risks or negative outcomes of certain actions. [!CAUTION] Advises about risks or negative outcomes of certain actions. [!CAUTION] Advises about risks or negative outcomes of certain actions. [!CAUTION] Advises about risks or negative outcomes of certain actions. Caution &gt; Advises about risks or negative outcomes of certain actions. footer content 35 </div>
@@ -70993,6 +76943,64 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
         Reveal.addEventListener('ready', function(event) {
             addBackgroundOverlay()
             updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             updateImageUrl('markdown/test')
             addCustomSlideNumber(event)
             fitContent()
@@ -71205,6 +77213,12 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('slidechanged', function(event) {
@@ -71415,7 +77429,71 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
             adjustFontSize()
             setFullPageBackground([{
                 "slideNumber": 2,
@@ -71624,6 +77702,12 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.addEventListener('resize', function() {
@@ -71835,6 +77919,2243 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                 "slide": "title-content",
                 "index": "21.2. ",
                 "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
+            }], 'markdown/test', 1123, 794)
+        })
+        Reveal.configure(config)
+        Reveal.initialize({
+            hash: true,
+
+            // Learn about plugins: https://revealjs.com/plugins/
+            plugins: [RevealAwesoMD, RevealHighlight, RevealNotes, RevealMermaid],
+        })
+    </script>
+    <script src="//localhost:35729/livereload.js?snipver=1" async="" defer=""></script>
+
+</body>
+
+</html>"
+`;
+
+exports[`test markdown presentation should render markdown presentation 36`] = `
+"<!DOCTYPE html>
+<html lang="en" class="reveal-full-page">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+    <title>footer content</title>
+
+    <link rel="stylesheet" href="dist/css/vendor.css">
+    <link rel="stylesheet" href="dist/css/metadata.css">
+    <style type="text/css">
+        .hljs-ln {
+            border-collapse: collapse
+        }
+
+        .hljs-ln td {
+            padding: 0
+        }
+
+        .hljs-ln-n:before {
+            content: attr(data-line-number)
+        }
+    </style>
+</head>
+
+<body class="reveal-viewport" style="--slide-width: 960px; --slide-height: 700px; --slide-scale: 1.6457142857142857; --viewport-width: 1920px; --viewport-height: 1200px;">
+    <div class="reveal slide center focused has-horizontal-slides ready" role="application" data-transition-speed="default" data-background-transition="slide">
+        <div class="slides" style="width: 960px; height: 700px; inset: 50% auto auto 50%; transform: translate(-50%, -50%) scale(1.64571);">
+            <section class="op-cover past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="cover-logo">
+                            <img src="templates/assets/op-logo-dark.png" alt="Logo">
+                        </div>
+
+                        <div class="content">
+                            <h1>footer content</h1>
+                            <p>
+                                presenter name
+                                - some description
+                            </p>
+
+                        </div>
+
+                    </div>
+                </div>
+
+            </section>
+            <section class="toc past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">
+                        Table of Contents
+
+                    </h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <ol style="font-size: 16px; margin-top: 0px; margin-bottom: 0px;">
+                                <li>Section Slide<ol>
+                                        <li>Title Content Slide</li>
+                                        <li>Title Content Image Slide</li>
+                                        <li>Title Content Image Slide - scale down font</li>
+                                    </ol>
+                                </li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC</li>
+                                <li>Section Slide for long TOC<ol>
+                                        <li>Mermaid JS</li>
+                                        <li>Support for alerts</li>
+                                        <li>Annotation</li>
+                                    </ol>
+                                </li>
+                            </ol>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">2</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">1. </h1>
+                            <h1 class="title">
+                                Section Slide
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">3</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.1. Title Content Slide</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p>some content</p>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">4</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.1. Title Image Slide</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">5</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.1. Title Image Slide to test image description &amp; credit</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">6</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.1. Title Image Slide to test image credit</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">7</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.1. Title Image Slide to test image credit without value</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">8</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.1. Title Image Slide to test invalid image metadata</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">9</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content-image past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.2. Title Content Image Slide</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p>some content</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <footer>
+                        <div class="footer-item footer-title">
+                            <p>footer content</p>
+                        </div>
+                        <div class="footer-item custom-slide-number">10</div>
+                        <div class="footer-item footer-logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
+                        </div>
+                    </footer>
+
+                </div>
+            </section>
+            <section class="title-content-image past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">1.3. Title Content Image Slide - scale down font</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
+                            <ul style="font-size: 11px; margin-top: 0px; margin-bottom: 0px;">
+                                <li>Lorem</li>
+                                <li>ipsum</li>
+                                <li>dolor</li>
+                                <li>sit</li>
+                                <li>amet</li>
+                                <li>consectetur</li>
+                                <li>adipisicing</li>
+                                <li>elit</li>
+                                <li>sed</li>
+                                <li>eiusmod</li>
+                                <li>tempor</li>
+                                <li>incidunt</li>
+                                <li>ut</li>
+                                <li>labore</li>
+                                <li>et</li>
+                                <li>dolore</li>
+                                <li>magna</li>
+                                <li>aliqua.</li>
+                                <li>Ut</li>
+                                <li>enim</li>
+                                <li>ad</li>
+                                <li>minim</li>
+                                <li>veniam</li>
+                            </ul>
+                            <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                            <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 208px; height: 158px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <footer>
+                        <div class="footer-item footer-title">
+                            <p>footer content</p>
+                        </div>
+                        <div class="footer-item custom-slide-number">11</div>
+                        <div class="footer-item footer-logo">
+                            <img src="templates/assets/op-logo-light.png" alt="Logo">
+                        </div>
+                    </footer>
+
+                </div>
+            </section>
+            <section class="image past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p>This is some content.</p>
+                        </div>
+                    </div>
+                </div>
+
+            </section>
+            <section class="image past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <p>some content</p>
+                        </div>
+                    </div>
+                </div>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">2. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">14</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">3. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">15</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">4. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">16</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">5. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">17</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">6. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">18</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">7. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">19</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">8. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">20</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">9. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">21</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">10. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">22</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">11. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">23</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">12. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">24</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">13. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">25</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">14. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">26</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">15. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">27</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">16. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">28</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">17. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">29</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">18. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">30</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">19. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">31</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">20. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">32</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="section past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: none;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <div class="content-wrapper">
+
+                        <div class="content">
+                            <h1 class="section-index">21. </h1>
+                            <h1 class="title">
+                                Section Slide for long TOC
+                            </h1>
+
+
+
+                        </div>
+
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">33</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">21.1. Mermaid JS</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <pre class="code-wrapper"><code class="mermaid hljs language-css" data-highlighted="yes"><svg aria-roledescription="flowchart-v2" role="graphics-document document" viewBox="0 0 239.53515625 567.796875" style="max-width: 239.53515625px;" class="flowchart" xmlns="http://www.w3.org/2000/svg" width="100%" id="mermaid-unique-id"><style>#mermaid-unique-id{font-family:"trebuchet ms",verdana,arial,sans-serif;font-size:16px;fill:#333;}#mermaid-unique-id .error-icon{fill:#552222;}#mermaid-unique-id .error-text{fill:#552222;stroke:#552222;}#mermaid-unique-id .edge-thickness-normal{stroke-width:1px;}#mermaid-unique-id .edge-thickness-thick{stroke-width:3.5px;}#mermaid-unique-id .edge-pattern-solid{stroke-dasharray:0;}#mermaid-unique-id .edge-thickness-invisible{stroke-width:0;fill:none;}#mermaid-unique-id .edge-pattern-dashed{stroke-dasharray:3;}#mermaid-unique-id .edge-pattern-dotted{stroke-dasharray:2;}#mermaid-unique-id .marker{fill:#333333;stroke:#333333;}#mermaid-unique-id .marker.cross{stroke:#333333;}#mermaid-unique-id svg{font-family:"trebuchet ms",verdana,arial,sans-serif;font-size:16px;}#mermaid-unique-id p{margin:0;}#mermaid-unique-id .label{font-family:"trebuchet ms",verdana,arial,sans-serif;color:#333;}#mermaid-unique-id .cluster-label text{fill:#333;}#mermaid-unique-id .cluster-label span{color:#333;}#mermaid-unique-id .cluster-label span p{background-color:transparent;}#mermaid-unique-id .label text,#mermaid-unique-id span{fill:#333;color:#333;}#mermaid-unique-id .node rect,#mermaid-unique-id .node circle,#mermaid-unique-id .node ellipse,#mermaid-unique-id .node polygon,#mermaid-unique-id .node path{fill:#ECECFF;stroke:#9370DB;stroke-width:1px;}#mermaid-unique-id .rough-node .label text,#mermaid-unique-id .node .label text,#mermaid-unique-id .image-shape .label,#mermaid-unique-id .icon-shape .label{text-anchor:middle;}#mermaid-unique-id .node .katex path{fill:#000;stroke:#000;stroke-width:1px;}#mermaid-unique-id .rough-node .label,#mermaid-unique-id .node .label,#mermaid-unique-id .image-shape .label,#mermaid-unique-id .icon-shape .label{text-align:center;}#mermaid-unique-id .node.clickable{cursor:pointer;}#mermaid-unique-id .root .anchor path{fill:#333333!important;stroke-width:0;stroke:#333333;}#mermaid-unique-id .arrowheadPath{fill:#333333;}#mermaid-unique-id .edgePath .path{stroke:#333333;stroke-width:2.0px;}#mermaid-unique-id .flowchart-link{stroke:#333333;fill:none;}#mermaid-unique-id .edgeLabel{background-color:rgba(232,232,232, 0.8);text-align:center;}#mermaid-unique-id .edgeLabel p{background-color:rgba(232,232,232, 0.8);}#mermaid-unique-id .edgeLabel rect{opacity:0.5;background-color:rgba(232,232,232, 0.8);fill:rgba(232,232,232, 0.8);}#mermaid-unique-id .labelBkg{background-color:rgba(232, 232, 232, 0.5);}#mermaid-unique-id .cluster rect{fill:#ffffde;stroke:#aaaa33;stroke-width:1px;}#mermaid-unique-id .cluster text{fill:#333;}#mermaid-unique-id .cluster span{color:#333;}#mermaid-unique-id div.mermaidTooltip{position:absolute;text-align:center;max-width:200px;padding:2px;font-family:"trebuchet ms",verdana,arial,sans-serif;font-size:12px;background:hsl(80, 100%, 96.2745098039%);border:1px solid #aaaa33;border-radius:2px;pointer-events:none;z-index:100;}#mermaid-unique-id .flowchartTitleText{text-anchor:middle;font-size:18px;fill:#333;}#mermaid-unique-id rect.text{fill:none;stroke-width:0;}#mermaid-unique-id .icon-shape,#mermaid-unique-id .image-shape{background-color:rgba(232,232,232, 0.8);text-align:center;}#mermaid-unique-id .icon-shape p,#mermaid-unique-id .image-shape p{background-color:rgba(232,232,232, 0.8);padding:2px;}#mermaid-unique-id .icon-shape rect,#mermaid-unique-id .image-shape rect{opacity:0.5;background-color:rgba(232,232,232, 0.8);fill:rgba(232,232,232, 0.8);}#mermaid-unique-id :root{--mermaid-unique-id:"trebuchet ms",verdana,arial,sans-serif;}</style><g><marker orient="auto" markerHeight="8" markerWidth="8" markerUnits="userSpaceOnUse" refY="5" refX="5" viewBox="0 0 10 10" class="marker flowchart-v2" id="mermaid-unique-id"><path style="stroke-width: 1; stroke-dasharray: 1, 0;" class="arrowMarkerPath" d="M 0 0 L 10 5 L 0 10 z"></path></marker><marker orient="auto" markerHeight="8" markerWidth="8" markerUnits="userSpaceOnUse" refY="5" refX="4.5" viewBox="0 0 10 10" class="marker flowchart-v2" id="mermaid-unique-id"><path style="stroke-width: 1; stroke-dasharray: 1, 0;" class="arrowMarkerPath" d="M 0 5 L 10 10 L 10 0 z"></path></marker><marker orient="auto" markerHeight="11" markerWidth="11" markerUnits="userSpaceOnUse" refY="5" refX="11" viewBox="0 0 10 10" class="marker flowchart-v2" id="mermaid-unique-id"><circle style="stroke-width: 1; stroke-dasharray: 1, 0;" class="arrowMarkerPath" r="5" cy="5" cx="5"></circle></marker><marker orient="auto" markerHeight="11" markerWidth="11" markerUnits="userSpaceOnUse" refY="5" refX="-1" viewBox="0 0 10 10" class="marker flowchart-v2" id="mermaid-unique-id"><circle style="stroke-width: 1; stroke-dasharray: 1, 0;" class="arrowMarkerPath" r="5" cy="5" cx="5"></circle></marker><marker orient="auto" markerHeight="11" markerWidth="11" markerUnits="userSpaceOnUse" refY="5.2" refX="12" viewBox="0 0 11 11" class="marker cross flowchart-v2" id="mermaid-unique-id"><path style="stroke-width: 2; stroke-dasharray: 1, 0;" class="arrowMarkerPath" d="M 1,1 l 9,9 M 10,1 l -9,9"></path></marker><marker orient="auto" markerHeight="11" markerWidth="11" markerUnits="userSpaceOnUse" refY="5.2" refX="-1" viewBox="0 0 11 11" class="marker cross flowchart-v2" id="mermaid-unique-id"><path style="stroke-width: 2; stroke-dasharray: 1, 0;" class="arrowMarkerPath" d="M 1,1 l 9,9 M 10,1 l -9,9"></path></marker><g class="root"><g class="clusters"></g><g class="edgePaths"><path marker-end="url(#mermaid-unique-id)" style="" class="edge-thickness-normal edge-pattern-solid edge-thickness-normal edge-pattern-solid flowchart-link" id="L_A_B_0" d="M126.125,62L126.125,66.167C126.125,70.333,126.125,78.667,126.195,86.417C126.266,94.167,126.406,101.334,126.476,104.917L126.547,108.501"></path><path marker-end="url(#mermaid-unique-id)" style="" class="edge-thickness-normal edge-pattern-solid edge-thickness-normal edge-pattern-solid flowchart-link" id="L_B_C_1" d="M105.28,178.952L95.994,188.593C86.708,198.234,68.135,217.515,58.849,232.656C49.563,247.797,49.563,258.797,49.563,264.297L49.563,269.797"></path><path marker-end="url(#mermaid-unique-id)" style="" class="edge-thickness-normal edge-pattern-solid edge-thickness-normal edge-pattern-solid flowchart-link" id="L_C_D_2" d="M49.563,327.797L49.563,333.964C49.563,340.13,49.563,352.464,52.909,364.225C56.255,375.986,62.948,387.175,66.294,392.77L69.641,398.364"></path><path marker-end="url(#mermaid-unique-id)" style="" class="edge-thickness-normal edge-pattern-solid edge-thickness-normal edge-pattern-solid flowchart-link" id="L_D_B_3" d="M103.994,401.797L107.682,395.63C111.371,389.464,118.748,377.13,122.436,360.297C126.125,343.464,126.125,322.13,126.125,300.797C126.125,279.464,126.125,258.13,126.199,242.047C126.273,225.963,126.422,215.13,126.496,209.713L126.57,204.296"></path><path marker-end="url(#mermaid-unique-id)" style="" class="edge-thickness-normal edge-pattern-solid edge-thickness-normal edge-pattern-solid flowchart-link" id="L_B_E_4" d="M145.527,181.395L152.489,190.628C159.452,199.862,173.376,218.329,180.339,238.23C187.301,258.13,187.301,279.464,187.301,300.797C187.301,322.13,187.301,343.464,187.301,364.797C187.301,386.13,187.301,407.464,187.301,426.797C187.301,446.13,187.301,463.464,187.301,475.63C187.301,487.797,187.301,494.797,187.301,498.297L187.301,501.797"></path></g><g class="edgeLabels"><g class="edgeLabel"><g transform="translate(0, 0)" class="label"><foreignObject height="0" width="0"><div style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center;" class="labelBkg" xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel"></span></div></foreignObject></g></g><g transform="translate(49.5625, 236.796875)" class="edgeLabel"><g transform="translate(-13.0546875, -12)" class="label"><foreignObject height="24" width="26.109375"><div style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center;" class="labelBkg" xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel"><p>Yes</p></span></div></foreignObject></g></g><g class="edgeLabel"><g transform="translate(0, 0)" class="label"><foreignObject height="0" width="0"><div style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center;" class="labelBkg" xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel"></span></div></foreignObject></g></g><g class="edgeLabel"><g transform="translate(0, 0)" class="label"><foreignObject height="0" width="0"><div style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center;" class="labelBkg" xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel"></span></div></foreignObject></g></g><g transform="translate(187.30078125, 364.796875)" class="edgeLabel"><g transform="translate(-10.2265625, -12)" class="label"><foreignObject height="24" width="20.453125"><div style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center;" class="labelBkg" xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel"><p>No</p></span></div></foreignObject></g></g></g><g class="nodes"><g transform="translate(126.125, 35)" id="flowchart-A-0" class="node default"><rect height="54" width="93.796875" y="-27" x="-46.8984375" style="" class="basic label-container"></rect><g transform="translate(-16.8984375, -12)" style="" class="label"><rect></rect><foreignObject height="24" width="33.796875"><div style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center;" xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel"><p>Start</p></span></div></foreignObject></g></g><g transform="translate(126.125, 155.8984375)" id="flowchart-B-1" class="node default"><polygon transform="translate(-43.8984375,43.8984375)" class="label-container" points="43.8984375,0 87.796875,-43.8984375 43.8984375,-87.796875 0,-43.8984375"></polygon><g transform="translate(-16.8984375, -12)" style="" class="label"><rect></rect><foreignObject height="24" width="33.796875"><div style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center;" xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel"><p>Is it?</p></span></div></foreignObject></g></g><g transform="translate(49.5625, 300.796875)" id="flowchart-C-3" class="node default"><rect height="54" width="83.125" y="-27" x="-41.5625" style="" class="basic label-container"></rect><g transform="translate(-11.5625, -12)" style="" class="label"><rect></rect><foreignObject height="24" width="23.125"><div style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center;" xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel"><p>OK</p></span></div></foreignObject></g></g><g transform="translate(87.84375, 428.796875)" id="flowchart-D-5" class="node default"><rect height="54" width="114.25" y="-27" x="-57.125" style="" class="basic label-container"></rect><g transform="translate(-27.125, -12)" style="" class="label"><rect></rect><foreignObject height="24" width="54.25"><div style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center;" xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel"><p>Rethink</p></span></div></foreignObject></g></g><g transform="translate(187.30078125, 532.796875)" id="flowchart-E-9" class="node default"><rect height="54" width="88.46875" y="-27" x="-44.234375" style="" class="basic label-container"></rect><g transform="translate(-14.234375, -12)" style="" class="label"><rect></rect><foreignObject height="24" width="28.46875"><div style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center;" xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel"><p>End</p></span></div></foreignObject></g></g></g></g></g></svg></code></pre>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">34</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content past" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;" hidden="" aria-hidden="true">
+                <div class="content-container">
+                    <h1 class="title">21.2. Support for alerts</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+
+
+                            <div class="alert note" style="font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Note</div>
+                                <blockquote>Useful information that users should know, even when skimming content.</blockquote>
+                            </div>
+
+                            <div class="alert caution" style="font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                            <div class="alert" style="font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
+                                <blockquote>[!something]</blockquote>
+                                <blockquote>Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                            <div class="alert" style="font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
+                                <blockquote>
+                                    <p>[!CAUTION]</p>
+                                </blockquote>
+                            </div>
+                            <div class="alert" style="font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
+                                <blockquote>
+                                    <p>Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+
+                            <div class="alert" style="--padding-top: 0px; --padding-bottom: 0px; font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
+                                <blockquote style="padding-top: 0px; padding-bottom: 0px; border-width: 0px 0px 0px 6px; border-style: solid; border-color: initial; border-image: initial;">
+                                    <blockquote>
+                                        <p>[!CAUTION]<br>Advises about risks or negative outcomes of certain actions.</p>
+                                    </blockquote>
+                                </blockquote>
+                            </div>
+
+                            <div class="alert" style="font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
+                                <blockquote>
+                                    <p>[!CAUTION] Advises about risks or negative outcomes of certain actions.</p>
+                                </blockquote>
+                            </div>
+
+                            <div class="alert caution" style="font-size: 15px; margin-top: 6px; margin-bottom: 6px;">
+                                <div class="alert-title"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                                        <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+                                    </svg> Caution</div>
+                                <blockquote>&gt; Advises about risks or negative outcomes of certain actions.</blockquote>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">35</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+            <section class="title-content present" data-markdown="" data-markdown-parsed="true" style="top: 0px; display: block;">
+                <div class="content-container">
+                    <h1 class="title">21.3. Annotation</h1>
+                    <div class="content-wrapper">
+                        <div class="content">
+
+                            <div class="image-container">
+                                <div class="image-wrapper" data-annotated="true"><canvas width="840" height="685"></canvas>
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <footer>
+                    <div class="footer-item footer-title">
+                        <p>footer content</p>
+                    </div>
+                    <div class="footer-item custom-slide-number">36</div>
+                    <div class="footer-item footer-logo">
+                        <img src="templates/assets/op-logo-light.png" alt="Logo">
+                    </div>
+                </footer>
+
+            </section>
+        </div>
+        <div class="backgrounds">
+            <div class="slide-background op-cover past" data-loaded="true" style="display: none;">
+                <div class="slide-background-content">
+                    <div class="image-overlay-container">
+                        <div class="image-container"><img src="templates/assets/OpenProject-Screen.png" alt="cover page" style="border-radius: 15px 0px 0px 15px;"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="slide-background toc past" data-loaded="true" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" data-loaded="true" style="display: none;">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content-image past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content-image past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background image past" style="display: none; background-image: url(&quot;markdown/test/test-16-9.png&quot;); background-repeat: no-repeat; background-size: cover; background-position: center center;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background image past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content">Please provide background image for this slide</div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background section past" style="display: none;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: block;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content past" style="display: block;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+            <div class="slide-background title-content present" style="display: block;" data-loaded="true">
+                <div class="slide-background-content"></div>
+            </div>
+        </div>
+        <div class="slide-number" style="display: none;"></div>
+        <aside class="controls" data-controls-layout="bottom-right" data-controls-back-arrows="faded" style="display: block;"><button class="navigate-left enabled" aria-label="previous slide">
+                <div class="controls-arrow"></div>
+            </button>
+            <button class="navigate-right" aria-label="next slide" disabled="disabled">
+                <div class="controls-arrow"></div>
+            </button>
+            <button class="navigate-up" aria-label="above slide" disabled="disabled">
+                <div class="controls-arrow"></div>
+            </button>
+            <button class="navigate-down" aria-label="below slide" disabled="disabled">
+                <div class="controls-arrow"></div>
+            </button>
+        </aside>
+        <div class="progress" style="display: block;"><span style="transform: scaleX(1);"></span></div>
+        <div class="speaker-notes" data-prevent-swipe="" tabindex="0"></div>
+        <div class="pause-overlay"><button class="resume-button">Resume presentation</button></div>
+        <div class="aria-status" aria-live="polite" aria-atomic="true" style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);">21.3. Annotation footer content 36 </div>
+    </div>
+    <script src="dist/js/vendor.js"></script>
+    <script src="dist/js/utils.js"></script>
+    <script src="config-reveal.js"></script>
+    <script src="utils/helper.js"></script>
+    <script>
+        // config is defined in config-reveal.js
+        Reveal.addEventListener('ready', function(event) {
+            addBackgroundOverlay()
+            updateImageStructure()
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
+            updateImageUrl('markdown/test')
+            addCustomSlideNumber(event)
+            fitContent()
+            adjustFontSize()
+            showHideFooterAndSlideNumber('yes', false)
+            setFullPageBackground([{
+                "slideNumber": 2,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "1. ",
+                "headingText": "Section Slide"
+            }, {
+                "slideNumber": 3,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Content Slide"
+            }, {
+                "slideNumber": 4,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide"
+            }, {
+                "slideNumber": 5,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image description & credit"
+            }, {
+                "slideNumber": 6,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit"
+            }, {
+                "slideNumber": 7,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit without value"
+            }, {
+                "slideNumber": 8,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test invalid image metadata"
+            }, {
+                "slideNumber": 9,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.2. ",
+                "headingText": "Title Content Image Slide"
+            }, {
+                "slideNumber": 10,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.3. ",
+                "headingText": "Title Content Image Slide - scale down font"
+            }, {
+                "slideNumber": 11,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "background": "test-16-9.png",
+                "pdfbackground": "test-4-3.png",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 12,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 13,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "2. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 14,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "3. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 15,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "4. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 16,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "5. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 17,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "6. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 18,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "7. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 19,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "8. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 20,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "9. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 21,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "10. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 22,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "11. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 23,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "12. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 24,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "13. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 25,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "14. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 26,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "15. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 27,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "16. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 28,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "17. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 29,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "18. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 30,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "19. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 31,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "20. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 32,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "21. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 33,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.1. ",
+                "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
+            }], 'markdown/test', 1123, 794)
+        })
+        Reveal.addEventListener('slidechanged', function(event) {
+            setIndex([{
+                "slideNumber": 2,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "1. ",
+                "headingText": "Section Slide"
+            }, {
+                "slideNumber": 3,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Content Slide"
+            }, {
+                "slideNumber": 4,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide"
+            }, {
+                "slideNumber": 5,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image description & credit"
+            }, {
+                "slideNumber": 6,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit"
+            }, {
+                "slideNumber": 7,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit without value"
+            }, {
+                "slideNumber": 8,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test invalid image metadata"
+            }, {
+                "slideNumber": 9,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.2. ",
+                "headingText": "Title Content Image Slide"
+            }, {
+                "slideNumber": 10,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.3. ",
+                "headingText": "Title Content Image Slide - scale down font"
+            }, {
+                "slideNumber": 11,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "background": "test-16-9.png",
+                "pdfbackground": "test-4-3.png",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 12,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 13,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "2. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 14,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "3. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 15,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "4. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 16,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "5. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 17,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "6. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 18,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "7. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 19,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "8. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 20,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "9. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 21,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "10. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 22,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "11. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 23,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "12. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 24,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "13. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 25,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "14. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 26,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "15. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 27,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "16. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 28,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "17. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 29,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "18. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 30,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "19. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 31,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "20. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 32,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "21. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 33,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.1. ",
+                "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
+            }])
+            annotateImage({
+                "0": {},
+                "1": {},
+                "2": {},
+                "3": {},
+                "4": {
+                    "test-image.jpg": []
+                },
+                "5": {
+                    "test-image.jpg": []
+                },
+                "6": {
+                    "test-image.jpg": []
+                },
+                "7": {
+                    "test-image.jpg": []
+                },
+                "8": {
+                    "test-image.jpg": []
+                },
+                "9": {
+                    "test-image.jpg": []
+                },
+                "10": {
+                    "test-image.jpg": []
+                },
+                "11": {},
+                "12": {},
+                "13": {},
+                "14": {},
+                "15": {},
+                "16": {},
+                "17": {},
+                "18": {},
+                "19": {},
+                "20": {},
+                "21": {},
+                "22": {},
+                "23": {},
+                "24": {},
+                "25": {},
+                "26": {},
+                "27": {},
+                "28": {},
+                "29": {},
+                "30": {},
+                "31": {},
+                "32": {},
+                "33": {},
+                "34": {},
+                "35": {
+                    "test-image.jpg": [{
+                        "x": "100",
+                        "y": "100",
+                        "text": "Test Annotation"
+                    }]
+                }
+            })
+            adjustFontSize()
+            setFullPageBackground([{
+                "slideNumber": 2,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "1. ",
+                "headingText": "Section Slide"
+            }, {
+                "slideNumber": 3,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Content Slide"
+            }, {
+                "slideNumber": 4,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide"
+            }, {
+                "slideNumber": 5,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image description & credit"
+            }, {
+                "slideNumber": 6,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit"
+            }, {
+                "slideNumber": 7,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit without value"
+            }, {
+                "slideNumber": 8,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test invalid image metadata"
+            }, {
+                "slideNumber": 9,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.2. ",
+                "headingText": "Title Content Image Slide"
+            }, {
+                "slideNumber": 10,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.3. ",
+                "headingText": "Title Content Image Slide - scale down font"
+            }, {
+                "slideNumber": 11,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "background": "test-16-9.png",
+                "pdfbackground": "test-4-3.png",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 12,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 13,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "2. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 14,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "3. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 15,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "4. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 16,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "5. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 17,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "6. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 18,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "7. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 19,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "8. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 20,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "9. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 21,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "10. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 22,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "11. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 23,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "12. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 24,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "13. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 25,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "14. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 26,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "15. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 27,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "16. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 28,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "17. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 29,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "18. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 30,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "19. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 31,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "20. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 32,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "21. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 33,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.1. ",
+                "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
+            }], 'markdown/test', 1123, 794)
+        })
+        Reveal.addEventListener('resize', function() {
+            addBackgroundOverlay()
+            setFullPageBackground([{
+                "slideNumber": 2,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "1. ",
+                "headingText": "Section Slide"
+            }, {
+                "slideNumber": 3,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Content Slide"
+            }, {
+                "slideNumber": 4,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide"
+            }, {
+                "slideNumber": 5,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image description & credit"
+            }, {
+                "slideNumber": 6,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit"
+            }, {
+                "slideNumber": 7,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test image credit without value"
+            }, {
+                "slideNumber": 8,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "title-content",
+                "index": "1.1. ",
+                "headingText": "Title Image Slide to test invalid image metadata"
+            }, {
+                "slideNumber": 9,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.2. ",
+                "headingText": "Title Content Image Slide"
+            }, {
+                "slideNumber": 10,
+                "headingLevel": 2,
+                "slide": "title-content-image",
+                "index": "1.3. ",
+                "headingText": "Title Content Image Slide - scale down font"
+            }, {
+                "slideNumber": 11,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "background": "test-16-9.png",
+                "pdfbackground": "test-4-3.png",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 12,
+                "headingLevel": 2,
+                "toc": "false",
+                "slide": "image",
+                "index": "",
+                "headingText": ""
+            }, {
+                "slideNumber": 13,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "2. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 14,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "3. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 15,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "4. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 16,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "5. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 17,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "6. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 18,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "7. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 19,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "8. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 20,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "9. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 21,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "10. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 22,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "11. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 23,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "12. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 24,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "13. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 25,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "14. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 26,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "15. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 27,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "16. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 28,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "17. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 29,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "18. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 30,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "19. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 31,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "20. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 32,
+                "headingLevel": 1,
+                "slide": "section",
+                "index": "21. ",
+                "headingText": "Section Slide for long TOC"
+            }, {
+                "slideNumber": 33,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.1. ",
+                "headingText": "Mermaid JS"
+            }, {
+                "slideNumber": 34,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.2. ",
+                "headingText": "Support for alerts"
+            }, {
+                "slideNumber": 35,
+                "headingLevel": 2,
+                "slide": "title-content",
+                "index": "21.3. ",
+                "headingText": "Annotation"
             }], 'markdown/test', 1123, 794)
         })
         Reveal.configure(config)

--- a/tests/unit/jest/presentation.spec.js
+++ b/tests/unit/jest/presentation.spec.js
@@ -92,7 +92,7 @@ beforeEach(async () => {
 describe('test markdown presentation', () => {
     it('should match the total number of slides', async () => {
         const totalSlides = await getTotalSlides()
-        expect(totalSlides).toEqual(35)
+        expect(totalSlides).toEqual(36)
     })
 
     it('should render markdown presentation', async () => {

--- a/tests/unit/testFiles/index.example.html
+++ b/tests/unit/testFiles/index.example.html
@@ -26,6 +26,7 @@
             Reveal.addEventListener('ready', function (event) {
                 addBackgroundOverlay()
                 updateImageStructure()
+                annotateImage({{{ imageAnnotationData }}})
                 updateImageUrl('{{{ imagePath }}}')
                 addCustomSlideNumber(event)
                 fitContent()
@@ -35,6 +36,7 @@
             })
             Reveal.addEventListener('slidechanged', function (event) {
                 setIndex({{{ headingData }}})
+                annotateImage({{{ imageAnnotationData }}})
                 adjustFontSize()
                 setFullPageBackground({{{ headingData }}}, '{{{ imagePath }}}', {{ config.pdfWidth }}, {{ config.pdfHeight }})
             })

--- a/tests/unit/testFiles/markdown/test/test.md
+++ b/tests/unit/testFiles/markdown/test/test.md
@@ -125,3 +125,9 @@ flowchart TD
 
 > [!CAUTION]
         > Advises about risks or negative outcomes of certain actions.
+
+## Annotation
+![test annotation](test-image.jpg)
+```annotation
+100|100|Test Annotation
+```


### PR DESCRIPTION
### Description
Added feature to add annotation/comment texts over images.

Provide image annotation below the image, for example
```md
    ## Annotation 1

    ![openproject screenshot ::credit: Source: https://community.openproject.org](openproject-screenshot.png)
    ```annotation
    100|100|Text annotation
    200|200|Annotation
    ```
```
This will result into the following slide:

![image](https://github.com/user-attachments/assets/118bbea3-b056-475a-a233-374a247fc36e)





### Related WP
https://community.openproject.org/projects/revealjs/work_packages/61782/activity