### PR TITLE
exclude linting test coverage

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -157,6 +157,7 @@ gulp.task('format', () =>
             '!templates/**',
             '!tests/unit/node_modules/**',
             '!tests/unit/testFiles/dist/**',
+            '!tests/unit/coverage/**',
         ])
         .pipe(prettier())
         .pipe(gulp.dest('.'))


### PR DESCRIPTION
### Desctiption
While running `lint:fix` command, the linter also checks inside the `tests/unit/coverage/` directory. So, excluding the `tests/unit/coverage` from format command.