### PR TITLE
[FIX] fix image structure

### DIFF
--- a/tests/unit/jest/__snapshots__/presentation.spec.js.snap
+++ b/tests/unit/jest/__snapshots__/presentation.spec.js.snap
@@ -166,13 +166,13 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -196,13 +196,13 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -226,13 +226,13 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -256,13 +256,13 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -286,13 +286,13 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -317,13 +317,13 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -375,13 +375,13 @@ exports[`test markdown presentation should render markdown presentation 1`] = `
                             </ul>
                             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -2225,13 +2225,13 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -2255,13 +2255,13 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -2285,13 +2285,13 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -2315,13 +2315,13 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -2345,13 +2345,13 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -2376,13 +2376,13 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -2434,13 +2434,13 @@ exports[`test markdown presentation should render markdown presentation 2`] = `
                             </ul>
                             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -4284,13 +4284,13 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -4314,13 +4314,13 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -4344,13 +4344,13 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -4374,13 +4374,13 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -4404,13 +4404,13 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -4435,13 +4435,13 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -4493,13 +4493,13 @@ exports[`test markdown presentation should render markdown presentation 3`] = `
                             </ul>
                             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -6341,13 +6341,13 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -6371,13 +6371,13 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -6401,13 +6401,13 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -6431,13 +6431,13 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -6461,13 +6461,13 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -6492,13 +6492,13 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -6550,13 +6550,13 @@ exports[`test markdown presentation should render markdown presentation 4`] = `
                             </ul>
                             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -8396,13 +8396,13 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -8426,13 +8426,13 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -8456,13 +8456,13 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -8486,13 +8486,13 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -8516,13 +8516,13 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -8547,13 +8547,13 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -8605,13 +8605,13 @@ exports[`test markdown presentation should render markdown presentation 5`] = `
                             </ul>
                             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -10451,13 +10451,13 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -10479,13 +10479,13 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -10509,13 +10509,13 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -10539,13 +10539,13 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -10569,13 +10569,13 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -10600,13 +10600,13 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -10658,13 +10658,13 @@ exports[`test markdown presentation should render markdown presentation 6`] = `
                             </ul>
                             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -12504,13 +12504,13 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -12532,13 +12532,13 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -12560,13 +12560,13 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -12590,13 +12590,13 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -12620,13 +12620,13 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -12651,13 +12651,13 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -12709,13 +12709,13 @@ exports[`test markdown presentation should render markdown presentation 7`] = `
                             </ul>
                             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -14555,13 +14555,13 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -14583,13 +14583,13 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -14611,13 +14611,13 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -14639,13 +14639,13 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -14669,13 +14669,13 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -14700,13 +14700,13 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -14758,13 +14758,13 @@ exports[`test markdown presentation should render markdown presentation 8`] = `
                             </ul>
                             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -16604,13 +16604,13 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -16632,13 +16632,13 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -16660,13 +16660,13 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -16688,13 +16688,13 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -16716,13 +16716,13 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -16747,13 +16747,13 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -16805,13 +16805,13 @@ exports[`test markdown presentation should render markdown presentation 9`] = `
                             </ul>
                             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -18651,13 +18651,13 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -18679,13 +18679,13 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -18707,13 +18707,13 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -18735,13 +18735,13 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -18763,13 +18763,13 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -18792,13 +18792,13 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -18850,13 +18850,13 @@ exports[`test markdown presentation should render markdown presentation 10`] = `
                             </ul>
                             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -20696,13 +20696,13 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -20724,13 +20724,13 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -20752,13 +20752,13 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -20780,13 +20780,13 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -20808,13 +20808,13 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -20837,13 +20837,13 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -20893,13 +20893,13 @@ exports[`test markdown presentation should render markdown presentation 11`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -22739,13 +22739,13 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -22767,13 +22767,13 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -22795,13 +22795,13 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -22823,13 +22823,13 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -22851,13 +22851,13 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -22880,13 +22880,13 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -22936,13 +22936,13 @@ exports[`test markdown presentation should render markdown presentation 12`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -24782,13 +24782,13 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -24810,13 +24810,13 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -24838,13 +24838,13 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -24866,13 +24866,13 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -24894,13 +24894,13 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -24923,13 +24923,13 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -24979,13 +24979,13 @@ exports[`test markdown presentation should render markdown presentation 13`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -26825,13 +26825,13 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -26853,13 +26853,13 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -26881,13 +26881,13 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -26909,13 +26909,13 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -26937,13 +26937,13 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -26966,13 +26966,13 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -27022,13 +27022,13 @@ exports[`test markdown presentation should render markdown presentation 14`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -28869,13 +28869,13 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -28897,13 +28897,13 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -28925,13 +28925,13 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -28953,13 +28953,13 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -28981,13 +28981,13 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -29010,13 +29010,13 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -29066,13 +29066,13 @@ exports[`test markdown presentation should render markdown presentation 15`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -30914,13 +30914,13 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -30942,13 +30942,13 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -30970,13 +30970,13 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -30998,13 +30998,13 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -31026,13 +31026,13 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -31055,13 +31055,13 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -31111,13 +31111,13 @@ exports[`test markdown presentation should render markdown presentation 16`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -32960,13 +32960,13 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -32988,13 +32988,13 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -33016,13 +33016,13 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -33044,13 +33044,13 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -33072,13 +33072,13 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -33101,13 +33101,13 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -33157,13 +33157,13 @@ exports[`test markdown presentation should render markdown presentation 17`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -35007,13 +35007,13 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -35035,13 +35035,13 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -35063,13 +35063,13 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -35091,13 +35091,13 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -35119,13 +35119,13 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -35148,13 +35148,13 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -35204,13 +35204,13 @@ exports[`test markdown presentation should render markdown presentation 18`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -37055,13 +37055,13 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -37083,13 +37083,13 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -37111,13 +37111,13 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -37139,13 +37139,13 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -37167,13 +37167,13 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -37196,13 +37196,13 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -37252,13 +37252,13 @@ exports[`test markdown presentation should render markdown presentation 19`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -39104,13 +39104,13 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -39132,13 +39132,13 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -39160,13 +39160,13 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -39188,13 +39188,13 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -39216,13 +39216,13 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -39245,13 +39245,13 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -39301,13 +39301,13 @@ exports[`test markdown presentation should render markdown presentation 20`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -41154,13 +41154,13 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -41182,13 +41182,13 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -41210,13 +41210,13 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -41238,13 +41238,13 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -41266,13 +41266,13 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -41295,13 +41295,13 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -41351,13 +41351,13 @@ exports[`test markdown presentation should render markdown presentation 21`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -43205,13 +43205,13 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -43233,13 +43233,13 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -43261,13 +43261,13 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -43289,13 +43289,13 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -43317,13 +43317,13 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -43346,13 +43346,13 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -43402,13 +43402,13 @@ exports[`test markdown presentation should render markdown presentation 22`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -45257,13 +45257,13 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -45285,13 +45285,13 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -45313,13 +45313,13 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -45341,13 +45341,13 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -45369,13 +45369,13 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -45398,13 +45398,13 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -45454,13 +45454,13 @@ exports[`test markdown presentation should render markdown presentation 23`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -47310,13 +47310,13 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -47338,13 +47338,13 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -47366,13 +47366,13 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -47394,13 +47394,13 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -47422,13 +47422,13 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -47451,13 +47451,13 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -47507,13 +47507,13 @@ exports[`test markdown presentation should render markdown presentation 24`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -49364,13 +49364,13 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -49392,13 +49392,13 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -49420,13 +49420,13 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -49448,13 +49448,13 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -49476,13 +49476,13 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -49505,13 +49505,13 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -49561,13 +49561,13 @@ exports[`test markdown presentation should render markdown presentation 25`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -51419,13 +51419,13 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -51447,13 +51447,13 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -51475,13 +51475,13 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -51503,13 +51503,13 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -51531,13 +51531,13 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -51560,13 +51560,13 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -51616,13 +51616,13 @@ exports[`test markdown presentation should render markdown presentation 26`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -53475,13 +53475,13 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -53503,13 +53503,13 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -53531,13 +53531,13 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -53559,13 +53559,13 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -53587,13 +53587,13 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -53616,13 +53616,13 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -53672,13 +53672,13 @@ exports[`test markdown presentation should render markdown presentation 27`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -55532,13 +55532,13 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -55560,13 +55560,13 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -55588,13 +55588,13 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -55616,13 +55616,13 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -55644,13 +55644,13 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -55673,13 +55673,13 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -55729,13 +55729,13 @@ exports[`test markdown presentation should render markdown presentation 28`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -57590,13 +57590,13 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -57618,13 +57618,13 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -57646,13 +57646,13 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -57674,13 +57674,13 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -57702,13 +57702,13 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -57731,13 +57731,13 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -57787,13 +57787,13 @@ exports[`test markdown presentation should render markdown presentation 29`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -59649,13 +59649,13 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -59677,13 +59677,13 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -59705,13 +59705,13 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -59733,13 +59733,13 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -59761,13 +59761,13 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -59790,13 +59790,13 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -59846,13 +59846,13 @@ exports[`test markdown presentation should render markdown presentation 30`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -61709,13 +61709,13 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -61737,13 +61737,13 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -61765,13 +61765,13 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -61793,13 +61793,13 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -61821,13 +61821,13 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -61850,13 +61850,13 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -61906,13 +61906,13 @@ exports[`test markdown presentation should render markdown presentation 31`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -63770,13 +63770,13 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -63798,13 +63798,13 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -63826,13 +63826,13 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -63854,13 +63854,13 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -63882,13 +63882,13 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -63911,13 +63911,13 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -63967,13 +63967,13 @@ exports[`test markdown presentation should render markdown presentation 32`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -65832,13 +65832,13 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -65860,13 +65860,13 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -65888,13 +65888,13 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -65916,13 +65916,13 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -65944,13 +65944,13 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -65973,13 +65973,13 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -66029,13 +66029,13 @@ exports[`test markdown presentation should render markdown presentation 33`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -67895,13 +67895,13 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -67923,13 +67923,13 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -67951,13 +67951,13 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -67979,13 +67979,13 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -68007,13 +68007,13 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -68036,13 +68036,13 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -68092,13 +68092,13 @@ exports[`test markdown presentation should render markdown presentation 34`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -69956,13 +69956,13 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="this: simple image description">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -69984,13 +69984,13 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="image description with credit">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -70012,13 +70012,13 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p>Source: https://www.example.com</p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p>Source: https://www.example.com</p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -70040,13 +70040,13 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -70068,13 +70068,13 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                     <div class="content-wrapper">
                         <div class="content">
 
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
                 </div>
@@ -70097,13 +70097,13 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                         <div class="content">
 
                             <p>some content</p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 
@@ -70153,13 +70153,13 @@ exports[`test markdown presentation should render markdown presentation 35`] = `
                             </ul>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                             <p style="font-size: 11px; margin-top: 10px; margin-bottom: 10px;"><strong>this line should be visible</strong></p>
-                            <p class="image-container">
-                            <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
-                                <div class="image-credit">
-                                    <p></p>
+                            <div class="image-container">
+                                <div class="image-wrapper"><img src="markdown/test/test-image.jpg" alt="" style="width: 25px; height: 22px;">
+                                    <div class="image-credit">
+                                        <p></p>
+                                    </div>
                                 </div>
                             </div>
-                            </p>
                         </div>
                     </div>
 

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -154,7 +154,7 @@ function updateImageUrl(imagePath) {
         } else {
             const match = url.pathname.match(/static\/(.+)/)
             if (match && match[1]) {
-                img.src = imagePath + '/' + match[1]
+                img.src = match[1]
             }
         }
 
@@ -175,18 +175,19 @@ function updateImageStructure() {
     const pTags = document.querySelectorAll('p > img')
     pTags.forEach((img) => {
         const pTag = img.parentNode
+        const divContainer = document.createElement('div')
+        divContainer.classList.add('image-container')
         const divWrapper = document.createElement('div')
         divWrapper.classList.add('image-wrapper')
         divWrapper.appendChild(img)
-        pTag.classList.add('image-container')
-        pTag.appendChild(divWrapper)
-
         const creditWrapper = document.createElement('div')
         creditWrapper.classList.add('image-credit')
         const credit = document.createElement('p')
         credit.textContent = getImageMetadata(img.alt)
         creditWrapper.appendChild(credit)
         divWrapper.appendChild(creditWrapper)
+        divContainer.appendChild(divWrapper)
+        pTag.replaceWith(divContainer)
     })
 }
 


### PR DESCRIPTION
### Description
With the use of JSDOM `dom.serialize()`, this won't allow `div` elements to append inside a `p`. The images are loaded inside the `p` tag when the markdown file is rendered. So while restructuring the image structure we had appended the `div` with class `image-wrapper` inside that `p` element. 
And the `dom.serialize()` won't allow that, resulting the image structure not updated and the content would overflow out of slides.

This  PR fixex this issue, changing the `p` tag to `div`.

### Related WP
https://community.openproject.org/projects/revealjs/work_packages/62263/activity